### PR TITLE
Use shared WebOnnx adapter to set readiness

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {TabNavigator} from "./util/nav";
 import {apiAvailable} from "./apiService";
 import {Fullscreen} from "./util/util";
 import * as util from "node:util";
-import {WebOnnxAdapter} from "./runtime/WebOnnxAdapter";
+import {webOnnx} from "./runtime/WebOnnxAdapter";
 
 customElements.define('gaze-element', GazeElement);
 // status fields and start button in UI
@@ -41,9 +41,8 @@ let subject: Subject | undefined = undefined;
 
 
 
-    const onnx = new WebOnnxAdapter();
-    await onnx.init('/models/gaze.onnx');  // path you’re already serving
-    await onnx.predict(new Float32Array(478 * 3));         // should log and return [x,y] without errors
+    await webOnnx.init('/models/gaze.onnx');  // path you’re already serving
+    await webOnnx.predict(new Float32Array(478 * 3));         // should log and return [x,y] without errors
 
     setUpDomElementVars();
 


### PR DESCRIPTION
## Summary
- use the exported `webOnnx` singleton instead of creating a new adapter in `index.ts`
- call `webOnnx.init` and `webOnnx.predict` so `webOnnx.ready` reflects initialization and JS inference is used instead of the Python backend

## Testing
- `npm test` *(fails: Missing script "test"))*
- `npm run build` *(fails: vite: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/onnxruntime-web)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'onnxruntime-web' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c51d8243c4832aa95aa4aca63efee8