### PR TITLE
Integrate PCA+MLP gaze inference pipeline

### DIFF
--- a/src/apiService.ts
+++ b/src/apiService.ts
@@ -75,8 +75,7 @@ export async function post_data(batch: BatchItem[]) : Promise<iGazeDetectorAddDa
 
     if (webOnnx.ready) {
         const last = batch[batch.length - 1];
-        const flat = new Float32Array(last.landmarks.flat());
-        const [gx, gy] = await webOnnx.predict(flat);
+        const [gx, gy] = await webOnnx.predict(last.landmarks);
         const [tx, ty] = last.target ?? [0, 0];
         const h_loss = Math.abs(gx - tx);
         const v_loss = Math.abs(gy - ty);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {apiAvailable} from "./apiService";
 import {Fullscreen} from "./util/util";
 import * as util from "node:util";
 import {webOnnx} from "./runtime/WebOnnxAdapter";
+import { PixelCoord } from "./util/Coords";
 
 customElements.define('gaze-element', GazeElement);
 // status fields and start button in UI
@@ -41,8 +42,8 @@ let subject: Subject | undefined = undefined;
 
 
 
-    await webOnnx.init('/models/gaze.onnx');  // path you’re already serving
-    await webOnnx.predict(new Float32Array(478 * 3));         // should log and return [x,y] without errors
+    await webOnnx.init();
+    await webOnnx.predict(Array.from({ length: 478 }, () => [0, 0, 0] as PixelCoord));
 
     setUpDomElementVars();
 

--- a/src/runtime/WebOnnxAdapter.ts
+++ b/src/runtime/WebOnnxAdapter.ts
@@ -1,12 +1,14 @@
 // src/runtime/WebOnnxAdapter.ts
 // If you load ORT via <script src=".../ort.min.js">, use: const ort = (window as any).ort;
 import * as ort from 'onnxruntime-web';
+import { PixelCoord } from '../util/Coords';
 
 export class WebOnnxAdapter {
-  private session?: ort.InferenceSession;
+  private pcaSession?: ort.InferenceSession;
+  private mlpSession?: ort.InferenceSession;
   ready = false;
 
-  async init(modelUrl: string) {
+  async init() {
     // Keep it simple: single-threaded, no proxy workers. (Threaded is fine too, but this removes that variable.)
     const env = (window as any).ort?.env ?? ort.env;
     env.logLevel = 'verbose';
@@ -14,30 +16,53 @@ export class WebOnnxAdapter {
     env.wasm.numThreads = 4;
     env.wasm.proxy = true;
 
-    this.session = await ort.InferenceSession.create(modelUrl, {
+    this.pcaSession = await ort.InferenceSession.create('/models/pca.onnx', {
       executionProviders: ['webgpu'],
       graphOptimizationLevel: 'all',
       extra: { 'session.use_ort_model_bytes_directly': '1' },
     });
 
-    // --- SMOKE TEST ---
-    const inputName = this.session.inputNames[0];
-    const dummy = new ort.Tensor('float32', new Float32Array(1 * 478 * 3), [1, 478, 3]);
-      const out = await this.session.run({ [inputName]: dummy });        // <-- plain object, not Map
-      const y = out[this.session.outputNames[0]] as ort.Tensor;          // <-- tensor, not Map/Seq
-      console.log('ORT smoke:', { inputName, outName: this.session.outputNames[0], dims: y.dims, dataLen: (y.data as Float32Array).length });
-      this.ready = true;
+    this.mlpSession = await ort.InferenceSession.create('/models/gaze_mlp.onnx', {
+      executionProviders: ['webgpu'],
+      graphOptimizationLevel: 'all',
+      extra: { 'session.use_ort_model_bytes_directly': '1' },
+    });
+
+    // --- SMOKE TEST --- end-to-end
+    const dummy = new ort.Tensor('float32', new Float32Array(478 * 3), [1, 478, 3]);
+    const pcaOutMap = await this.pcaSession.run({ [this.pcaSession.inputNames[0]]: dummy });
+    const pcaOut = pcaOutMap[this.pcaSession.outputNames[0]] as ort.Tensor;
+    const mlpInput = new ort.Tensor('float32', pcaOut.data as Float32Array, [1, 32]);
+    const mlpOutMap = await this.mlpSession.run({ [this.mlpSession.inputNames[0]]: mlpInput });
+    const mlpOut = mlpOutMap[this.mlpSession.outputNames[0]] as ort.Tensor;
+    console.log('ORT smoke:', {
+      pcaOutDims: pcaOut.dims,
+      mlpOutDims: mlpOut.dims,
+      dataLen: (mlpOut.data as Float32Array).length,
+    });
+    this.ready = true;
+  }
+
+  async predict(landmarks: PixelCoord[]): Promise<[number, number]> {
+    if (!this.pcaSession || !this.mlpSession) throw new Error('ORT sessions not initialized');
+    if (landmarks.length !== 478) throw new Error(`Expected 478 landmarks, got ${landmarks.length}`);
+
+    const flat = new Float32Array(478 * 3);
+    for (let i = 0; i < 478; i++) {
+      const lm = landmarks[i];
+      flat[i * 3] = lm[0] ?? 0;
+      flat[i * 3 + 1] = lm[1] ?? 0;
+      flat[i * 3 + 2] = lm[2] ?? 0;
     }
 
-  async predict(flatLandmarks: Float32Array): Promise<[number, number]> {
-    if (!this.session) throw new Error('ORT session not initialized');
-    if (flatLandmarks.length !== 478 * 3) throw new Error(`Expected 1434 floats, got ${flatLandmarks.length}`);
+    const pcaInput = new ort.Tensor('float32', flat, [1, 478, 3]);
+    const pcaOutMap = await this.pcaSession.run({ [this.pcaSession.inputNames[0]]: pcaInput });
+    const pcaOut = pcaOutMap[this.pcaSession.outputNames[0]] as ort.Tensor;
 
-    const inputName = this.session.inputNames[0];
-    const x = new ort.Tensor('float32', flatLandmarks, [1, 478, 3]);
-    const out = await this.session.run({ [inputName]: x });            // <-- plain object
-    const y = out[this.session.outputNames[0]] as ort.Tensor;          // <-- tensor
-    const v = y.data as Float32Array;                                  // <-- use .data, not .getValue()
+    const mlpInput = new ort.Tensor('float32', pcaOut.data as Float32Array, [1, 32]);
+    const mlpOutMap = await this.mlpSession.run({ [this.mlpSession.inputNames[0]]: mlpInput });
+    const mlpOut = mlpOutMap[this.mlpSession.outputNames[0]] as ort.Tensor;
+    const v = mlpOut.data as Float32Array;
     return [v[0], v[1]];
   }
 }


### PR DESCRIPTION
## Summary
- Add separate PCA and MLP ONNX sessions and run end-to-end smoke test on init
- Update prediction to accept raw landmarks, run PCA then MLP for gaze output
- Adjust API service and startup script to use new raw-landmark predict API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c52b26dae4832aba6980427400a677