### PR TITLE
fix: ensure PCA ONNX output node matches graph

### DIFF
--- a/pkg/tools/export_onnx.py
+++ b/pkg/tools/export_onnx.py
@@ -34,7 +34,12 @@ def export_pca(pca, out_path: str, opset: int) -> None:
     )
 
     # Adjust graph to accept [1, 478, 3] input and flatten internally
+    # Rename both the graph output and the producing node so the checker
+    # sees a valid connection (the original skl2onnx export names the
+    # final output something like "variable").
     pca_model.graph.output[0].name = "pca"
+    if pca_model.graph.node:
+        pca_model.graph.node[-1].output[0] = "pca"
 
     # Insert new 3D input
     landmarks = helper.make_tensor_value_info(


### PR DESCRIPTION
## Summary
- fix PCA export so ONNX graph output name matches final node output

## Testing
- `python -m pkg.tools.export_onnx --config cache/config.json --pca-out cache/checkpoints/pca.onnx --mlp-out cache/checkpoints/gaze_mlp.onnx` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c516b40c4c832a9fd6e6d1919297e2