### PR TITLE
Refactor initialization with class-based state and DOM helpers

### DIFF
--- a/src/domRefs.ts
+++ b/src/domRefs.ts
@@ -1,0 +1,13 @@
+export interface DomRefs {
+    startGazeDetectionButton: HTMLButtonElement;
+    statusDiv: HTMLDivElement;
+    indicatorApiAvailableEl: HTMLDivElement;
+}
+
+export function getDomRefs(): DomRefs {
+    return {
+        startGazeDetectionButton: document.querySelector('#startGazeDetectionButton') as HTMLButtonElement,
+        statusDiv: document.querySelector('#statusDiv') as HTMLDivElement,
+        indicatorApiAvailableEl: document.querySelector('.api-avail-indicator') as HTMLDivElement,
+    };
+}


### PR DESCRIPTION
## Summary
- consolidate DOM queries in new `domRefs` helper module
- introduce `App` class to hold controller and polling state
- run initialization via `init()` on `DOMContentLoaded`

## Testing
- `npm run build-dev`


------
https://chatgpt.com/codex/tasks/task_e_68c535259df8832a806c351871f2879f