### PR TITLE
Centralize DOM references via UI class

### DIFF
--- a/src/GazeDetector.ts
+++ b/src/GazeDetector.ts
@@ -5,6 +5,7 @@ import {LandMarkDetector} from "./LandMarkDetector";
 import {FaceLandmarker} from "@mediapipe/tasks-vision";
 import {ContinuousTrainer} from "./ContinuousTrainer";
 import {GazeElement} from "./GazeElement";
+import { ui } from "./UI";
 import {Coord, PixelCoord} from "./util/Coords";
 import {post_data} from "./apiService";
 
@@ -331,7 +332,7 @@ export class GazeDetector extends EventEmitter {
 
         this.landmarkDetector = new LandMarkDetector(videoCaptureElement);
 
-        const plotsDiv: HTMLDivElement = document.querySelector('#plots') as HTMLDivElement;
+        const plotsDiv: HTMLDivElement = ui.plotsDiv;
 
 
         this.videoCaptureElement = videoCaptureElement;
@@ -361,8 +362,8 @@ export class GazeDetector extends EventEmitter {
             this_.target_pos = this_.next_target_pos
         });
 
-        this.containerDiv = <HTMLDivElement>document.querySelector('.vidcap')
-        this.overlayCanvas = <HTMLCanvasElement>document.querySelector('#overlayCanvas')
+        this.containerDiv = ui.vidCapContainer;
+        this.overlayCanvas = ui.overlayCanvas;
         this.overlayCtx = this.overlayCanvas.getContext("2d") as CanvasRenderingContext2D;
         // Append in this order for z-order (gaze above target)
         document.documentElement.appendChild(targetElement);

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -11,13 +11,14 @@ A session consists of a Hypnotherapist and Subject interacting.  The therapist s
  Verbal responses (what the subject says)
  */
 import {Subject} from "./Subject";
+import { ui } from "./UI";
 
 
 export class Session {
     notificationDiv: HTMLDivElement
 
     constructor(private subject: Subject) {
-        this.notificationDiv = <HTMLDivElement>document.querySelector('.notification');
+        this.notificationDiv = ui.notificationDiv;
     }
 
     private Notify(message: string): void {

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -2,6 +2,7 @@ import EventEmitter from "eventemitter3";
 
 import {GazeDetector, iGazeDetectorResult} from "./GazeDetector";
 import {save_gaze_model} from "./apiService";
+import { ui } from "./UI";
 
 
 export class Subject extends EventEmitter {
@@ -83,10 +84,9 @@ export class Subject extends EventEmitter {
             return;
         this.isGazeDetectionActive = true;
         if (!this.gazeDetector)
-            this.gazeDetector = new GazeDetector(<HTMLVideoElement>document.querySelector("#vidCap"),
-                <HTMLDivElement>document.querySelector(".landmark_selector"));
+            this.gazeDetector = new GazeDetector(ui.vidCap, ui.landmarkSelector);
 
-        const vidcap_overlay = <HTMLDivElement>document.getElementById('vidCapOverlay');
+        const vidcap_overlay = ui.vidCapOverlay;
 
         this.gazeDetector.on('ProcessedFrame', () => {
                 // @ts-ignore

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -1,0 +1,27 @@
+export class UI {
+  startGazeDetectionButton: HTMLButtonElement;
+  apiIndicator: HTMLDivElement;
+  plotsDiv: HTMLDivElement;
+  vidCapOverlay: HTMLDivElement;
+  overlayCanvas: HTMLCanvasElement;
+  vidCap: HTMLVideoElement;
+  vidCapContainer: HTMLDivElement;
+  landmarkSelector: HTMLDivElement;
+  notificationDiv: HTMLDivElement;
+  pageTabs: HTMLElement;
+
+  constructor() {
+    this.startGazeDetectionButton = document.querySelector('#startGazeDetectionButton') as HTMLButtonElement;
+    this.apiIndicator = document.querySelector('.api-avail-indicator') as HTMLDivElement;
+    this.plotsDiv = document.querySelector('#plots') as HTMLDivElement;
+    this.vidCapOverlay = document.getElementById('vidCapOverlay') as HTMLDivElement;
+    this.overlayCanvas = document.querySelector('#overlayCanvas') as HTMLCanvasElement;
+    this.vidCap = document.querySelector('#vidCap') as HTMLVideoElement;
+    this.vidCapContainer = document.querySelector('.vidcap') as HTMLDivElement;
+    this.landmarkSelector = document.querySelector('.landmark_selector') as HTMLDivElement;
+    this.notificationDiv = document.querySelector('.notification') as HTMLDivElement;
+    this.pageTabs = document.querySelector('.page-tabs') as HTMLElement;
+  }
+}
+
+export const ui = new UI();

--- a/src/util/nav.ts
+++ b/src/util/nav.ts
@@ -39,6 +39,8 @@
  *
  */
 
+import { ui } from "../UI";
+
 class TabNavigator_class {
 
     public switchToPage(page_id: string) {
@@ -56,7 +58,7 @@ class TabNavigator_class {
     }
 
     constructor() {
-        const tabContainer = document.querySelector('.page-tabs')
+        const tabContainer = ui.pageTabs;
         if (tabContainer === null)
             window.alert("Can't construct tab navigator, couldn't find a tab container element in document (with the class'page-tabs'.")
         else {


### PR DESCRIPTION
## Summary
- Add `UI` registry to initialize and share DOM elements
- Refactor modules to access DOM nodes through the shared `ui` instance

## Testing
- `npm install` *(fails: 403 Forbidden - onnxruntime-web)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c56bfb2948832a903aadc9f6894baf