### PR TITLE
refactor: centralize coordinate conversion utilities

### DIFF
--- a/src/util/Coords.ts
+++ b/src/util/Coords.ts
@@ -2,5 +2,28 @@
 Handle coordinate transformations and calculations
  */
 
-export type Coord = { x: number; y: number; }
-export type PixelCoord = number[]
+export type Coord = { x: number; y: number; };
+export type PixelCoord = [number, number, number];
+
+export function modelToScreenCoords(point: Coord | PixelCoord): Coord {
+    let x: number, y: number;
+    if (Array.isArray(point)) {
+        x = point[0];
+        y = point[1];
+    } else {
+        x = point.x;
+        y = point.y;
+        x = ((x / 2) + 0.5) * screen.width;
+        y = ((y / 2) + 0.5) * screen.height;
+    }
+    return { x: Math.round(x), y: Math.round(y) };
+}
+
+export function screenToModelCoords(point: Coord | undefined): Coord | undefined {
+    if (!point) return undefined;
+    let { x, y } = point;
+    x = ((x / screen.width) - 0.5) * 2;
+    y = ((y / screen.height) - 0.5) * 2;
+    return { x, y };
+}
+


### PR DESCRIPTION
## Summary
- define PixelCoord as a tuple
- add model-to-screen and screen-to-model conversion helpers
- update gaze detector to use shared coordinate utilities

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68c588fb84ec832ab8c8c81ca0641824