### PR TITLE
Refactor gaze detector into modular components

### DIFF
--- a/src/GazeDetector.ts
+++ b/src/GazeDetector.ts
@@ -1,49 +1,160 @@
-
 import EventEmitter from "eventemitter3";
 
 import {LandMarkDetector} from "./LandMarkDetector";
 import {FaceLandmarker} from "@mediapipe/tasks-vision";
 import {GazeElement} from "./GazeElement";
 import { ui } from "./UI";
-import {Coord, PixelCoord, modelToScreenCoords, screenToModelCoords} from "./util/Coords";
+import {Coord, modelToScreenCoords} from "./util/Coords";
 import type {iGazeDetectorAddDataResult, IGazeTrainer} from "./training/Trainer";
-// https://github.com/webrtcHacks/tfObjWebrtc/blob/master/static/objDetect.js
+import {LandmarkRenderer} from "./LandmarkRenderer";
+import {TargetManager} from "./TargetManager";
+import {SampleCollector} from "./SampleCollector";
+
 export class GazeDetector extends EventEmitter {
-//for starting events
     isPlaying: boolean = false;
     gotMetaData: boolean = false;
 
     training_loss: number = -1;
     frame_rate: number = 0;
-    private trainer: IGazeTrainer | undefined = undefined;
+
     private containerDiv: HTMLDivElement;
-
-//create a canvas to grab an image for upload
-//     imageCanvas: HTMLCanvasElement;
-//     imageCtx: CanvasRenderingContext2D;
-
     overlayCanvas: HTMLCanvasElement;
-    overlayCtx: CanvasRenderingContext2D;
 
-    private target_pos: Coord | undefined = undefined;
-    private next_target_pos: Coord | undefined = undefined;
-    private targetElement: GazeElement;
+    videoCaptureElement: HTMLVideoElement;
 
-    // target won't be set until 'transitionend' event is fired,
-    // i.e. when the target element has reached its new position
+    private landmarkDetector: LandMarkDetector;
+    private landmarkRenderer: LandmarkRenderer;
+    private targetManager: TargetManager;
+    private sampleCollector: SampleCollector;
+    private gazeElement: GazeElement;
+
+    constructor(videoCaptureElement: HTMLVideoElement, landmarkSelectorElement: HTMLDivElement | undefined) {
+        super();
+
+        this.videoCaptureElement = videoCaptureElement;
+        this.landmarkDetector = new LandMarkDetector(videoCaptureElement);
+
+        this.containerDiv = ui.vidCapContainer;
+        this.overlayCanvas = ui.overlayCanvas;
+        this.landmarkRenderer = new LandmarkRenderer(this.overlayCanvas);
+
+        const gazeElement = <GazeElement>document.createElement('gaze-element');
+        const targetElement = <GazeElement>document.createElement('gaze-element');
+
+        gazeElement.setBackground(`radial-gradient(#97dc81, #2f560900)`);
+        gazeElement.setRadius(10, 10);
+        gazeElement.setTransitionStyle('all 0.2s ease-in-out');
+
+        targetElement.setPosition(undefined);
+        targetElement.setTransitionStyle('all 0.4s ease-in-out');
+        targetElement.setRadius(25, 25);
+
+        document.documentElement.appendChild(targetElement);
+        document.documentElement.appendChild(gazeElement);
+
+        this.targetManager = new TargetManager(targetElement);
+        this.gazeElement = gazeElement;
+        this.sampleCollector = new SampleCollector();
+
+        this.sampleCollector.on('prediction', (features: iGazeDetectorAddDataResult) => {
+            this.training_loss = features.losses.loss;
+            features.gaze = modelToScreenCoords(features.gaze);
+            this.emit('GazeDetectionComplete', features);
+        });
+
+        this.targetManager.on('targetUpdated', (pos: Coord | undefined) => {
+            this.emit('TargetUpdated', pos);
+        });
+
+        this.on('GazeDetectionComplete', (features: iGazeDetectorAddDataResult) => {
+            this.gazeElement.setPosition(features.gaze);
+            this.targetManager.updateFeedback(features);
+        });
+
+        if (landmarkSelectorElement) {
+            const GroupsElement = <HTMLDivElement>landmarkSelectorElement.children[0];
+            const CheckboxesElement = <HTMLDivElement>landmarkSelectorElement.children[1];
+            const displayLandmarkArray = this.landmarkRenderer.displayLandmarkArray;
+            for (let i = 0; i < 478; ++i) {
+                const checkBoxEl = document.createElement('input');
+                checkBoxEl.type = 'checkbox';
+                checkBoxEl.title = '' + i;
+                checkBoxEl.style.cursor = 'crosshair';
+                displayLandmarkArray.push({color: '#ffffff', visible: false});
+                checkBoxEl.addEventListener('click', (evt) => {
+                    const el = <HTMLInputElement>evt.target;
+                    displayLandmarkArray[Number.parseInt(el.title)].visible = el.checked;
+                });
+                checkBoxEl.addEventListener('mouseenter', (evt) => {
+                    const el = <HTMLInputElement>evt.target;
+                    displayLandmarkArray[Number.parseInt(el.title)].visible = true;
+                });
+                checkBoxEl.addEventListener('mouseleave', (evt) => {
+                    const el = <HTMLInputElement>evt.target;
+                    displayLandmarkArray[Number.parseInt(el.title)].visible = el.checked;
+                });
+                CheckboxesElement.appendChild(checkBoxEl);
+            }
+
+            for (const lms of [
+                {connections: [], indexes:  [127, 162, 21, 54, 103, 67, 109, 10, 338, 297, 332, 284, 251, 389,356,], color: '#ffffff', name: 'l2s_r1'},
+                {connections: [], indexes:  [246, 161, 160, 159, 158, 157, 173, 8, 398, 384, 385, 386, 387, 388, 466,], color: '#ffffff', name: 'l2s_r2'},
+                {connections: [], indexes:  [33, 470, 471, 468, 469, 472, 133, 168, 362, 477, 476, 473, 474, 475, 263,], color: '#ffffff', name: 'l2s_r3'},
+                {connections: [], indexes:  [7, 163, 144, 145, 153, 154, 155, 6, 382, 381, 380, 374, 373, 390, 249,], color: '#ffffff', name: 'l2s_r4'},
+                {connections: [], indexes:  [132, 147, 187, 207, 206, 165, 167, 164, 393, 391, 426, 427, 411, 376, 361,], color: '#ffffff', name: 'l2s_r5'},
+                {connections: FaceLandmarker.FACE_LANDMARKS_FACE_OVAL, indexes: [], color: '#800000', name: 'face-oval'},
+                {connections: FaceLandmarker.FACE_LANDMARKS_LEFT_EYE, indexes: [], color: '#0010ff', name: 'left-eye'},
+                {connections: FaceLandmarker.FACE_LANDMARKS_RIGHT_EYE, indexes: [], color: '#00507f', name: 'right-eye'},
+                {connections: FaceLandmarker.FACE_LANDMARKS_LEFT_EYEBROW, indexes: [], color: '#009f30', name: 'left-eyebrow'},
+                {connections: FaceLandmarker.FACE_LANDMARKS_RIGHT_EYEBROW, indexes: [], color: '#007f60', name: 'right-eyebrow'},
+                {connections: FaceLandmarker.FACE_LANDMARKS_LEFT_IRIS, indexes: [],color: '#ffff00', name: 'left-iris'},
+                {connections: FaceLandmarker.FACE_LANDMARKS_RIGHT_IRIS, indexes: [],color: '#8f8f00', name: 'right-iris'},
+                {connections: FaceLandmarker.FACE_LANDMARKS_LIPS, indexes: [],color: '#ff8de2', name: 'lips'},
+
+            ]) {
+                const groupCheckBoxEl = document.createElement('input');
+                const groupCheckBoxLabelEl = document.createElement('label');
+
+                groupCheckBoxLabelEl.appendChild(document.createTextNode(lms.name));
+
+                groupCheckBoxEl.type = 'checkbox';
+                groupCheckBoxEl.style.accentColor = lms.color;
+                groupCheckBoxLabelEl.appendChild(groupCheckBoxEl);
+                groupCheckBoxEl.addEventListener('click', (evt) => {
+                    const el = <HTMLInputElement>evt.target;
+                    for (const c of lms.connections) {
+                        const checkBoxEl = <HTMLInputElement>CheckboxesElement.children[c.start];
+                        checkBoxEl.checked = el.checked;
+                        checkBoxEl.style.accentColor = lms.color;
+                        displayLandmarkArray[c.start] = {visible: el.checked, color: lms.color};
+                    }
+                    for (const i of lms.indexes) {
+                        const checkBoxEl = <HTMLInputElement>CheckboxesElement.children[i];
+                        checkBoxEl.checked = el.checked;
+                        checkBoxEl.style.accentColor = lms.color;
+                        displayLandmarkArray[i] = {visible: el.checked, color: lms.color};
+                    }
+
+                })
+                GroupsElement.appendChild(groupCheckBoxLabelEl);
+            }
+        }
+    }
+
+    public set Trainer(t: IGazeTrainer | undefined) {
+        this.sampleCollector.Trainer = t;
+    }
+
+    public get Trainer(): IGazeTrainer | undefined {
+        return this.sampleCollector.Trainer;
+    }
+
     public set TargetPos(next_target_pos: Coord | undefined) {
-
-        const targetElement = this.targetElement;
-        if (next_target_pos === undefined)
-            this.target_pos = undefined;  // Don't wait for transition to end if we're stopping calibration
-
-        // setVisiblePosition() may set the target's position to a different value, it may adjust it to fit screen
-        this.next_target_pos = targetElement.setPosition(next_target_pos);
-
+        this.targetManager.TargetPos = next_target_pos;
     }
 
     public get TargetPos(): Coord | undefined {
-        return this.next_target_pos;
+        return this.targetManager.TargetPos;
     }
 
     public get FrameRate(): number {
@@ -51,34 +162,14 @@ export class GazeDetector extends EventEmitter {
     }
 
     public get isTraining(): boolean {
-        return this.trainer?.isTraining ?? false;
+        return this.sampleCollector.Trainer?.isTraining ?? false;
     }
-
-    // public Mode: GazeDetectorMode = 'features';
-
-    videoCaptureElement: HTMLVideoElement;
 
     public async term() {
         this.removeAllListeners();
         this.isPlaying = false;
         const v = this.videoCaptureElement;
         v.srcObject = v.onloadedmetadata = v.onplaying = null;
-    }
-
-    private onTrainerPrediction = (features: iGazeDetectorAddDataResult) => {
-        this.training_loss = features.losses.loss;
-        features.gaze = modelToScreenCoords(features.gaze);
-        this.emit('GazeDetectionComplete', features);
-    };
-
-    public set Trainer(t: IGazeTrainer | undefined) {
-        if (this.trainer) this.trainer.off('prediction', this.onTrainerPrediction);
-        this.trainer = t;
-        if (t) t.on('prediction', this.onTrainerPrediction);
-    }
-
-    public get Trainer(): IGazeTrainer | undefined {
-        return this.trainer;
     }
 
     public async init() {
@@ -132,7 +223,7 @@ export class GazeDetector extends EventEmitter {
 
     }
 
-    async startGazeDetection() {
+    private startGazeDetection() {
         const this_ = this;
         const v = this.videoCaptureElement;
         v.width = v.videoWidth;
@@ -141,25 +232,20 @@ export class GazeDetector extends EventEmitter {
 
         const overlayCanvas = this.overlayCanvas;
 
-        const overlayCtx = this.overlayCtx;
-
         console.log("starting gaze detection");
 
         overlayCanvas.width = v.videoWidth; // uploadWidth;
         overlayCanvas.height = v.videoHeight; //uploadWidth * (v.videoHeight / v.videoWidth);
 
-        // If user clicks on the overlay canvas, we set the target position to the clicked point in absolute screen coordinates (not local to the canvas)
         overlayCanvas.addEventListener('click', (evt) => {
             const x = evt.screenX;
             const y = evt.screenY;
             this_.TargetPos = {x: x, y: y};
 
         });
-        // set the TargetPos to undefined when the mouse leaves the overlay canvas
         overlayCanvas.addEventListener('mouseleave', () => {
             this_.TargetPos = undefined;
         });
-        // set the cursor to a crosshair when hovering over the overlay canvas
         overlayCanvas.style.cursor = 'crosshair';
 
         let frame_count: number = 0;
@@ -179,25 +265,9 @@ export class GazeDetector extends EventEmitter {
 
                 if (landmarks) {
 
-                    // Overlay the landmarks
+                    this.landmarkRenderer.render(landmarks);
 
-                    overlayCtx.clearRect(0, 0, 10000, 10000)
-
-                    for (const [idx, point] of landmarks.entries()) {
-                        const lms = this.displayLandmarkArray[idx];
-                        if (lms.visible) {
-                            overlayCtx.fillStyle = lms.color;
-                            overlayCtx.setTransform({a: -1, e: overlayCanvas.width})
-                            overlayCtx.beginPath();
-                            overlayCtx.arc(point.x * overlayCanvas.width, point.y * overlayCanvas.height, 2, 0, 2 * Math.PI);
-                            overlayCtx.fill();
-                        }
-                    }
-                    const landmarks_as_array = landmarks.map((p) => [p.x, p.y, p.z]);
-
-                    const target_ = this_.target_pos ? screenToModelCoords(this_.target_pos) : null;
-
-                    this_.trainer?.addSample({ landmarks: landmarks_as_array, target: target_ ? [ target_.x, target_.y] : null });
+                    this.sampleCollector.collect(landmarks, this.targetManager.CurrentTarget);
 
                 }
 
@@ -215,162 +285,6 @@ export class GazeDetector extends EventEmitter {
 
         this.videoCaptureElement.requestVideoFrameCallback(processFrame);
 
-    }
-
-    private landmarkDetector: LandMarkDetector;
-
-    private displayLandmarkArray: { visible: boolean, color: string }[] = [];
-
-    constructor(videoCaptureElement: HTMLVideoElement, landmarkSelectorElement: HTMLDivElement | undefined) {
-        super();
-
-
-        this.landmarkDetector = new LandMarkDetector(videoCaptureElement);
-
-        const plotsDiv: HTMLDivElement = ui.plotsDiv;
-
-
-        this.videoCaptureElement = videoCaptureElement;
-
-
-        const gazeElement = <GazeElement>document.createElement('gaze-element');
-        const targetElement = <GazeElement>document.createElement('gaze-element');
-
-        gazeElement.setBackground(`radial-gradient(#97dc81, #2f560900)`);
-        gazeElement.setRadius(10, 10);
-        gazeElement.setTransitionStyle('all 0.2s ease-in-out')
-
-        // Hide the target element
-        targetElement.setPosition(undefined);
-
-        targetElement.setTransitionStyle('all 0.4s ease-in-out');
-        // Default size for target.
-        // Will change size and shape during training to reflect horizontal and vertical loss
-        targetElement.setRadius(25, 25);
-
-        const this_ = this;
-
-        // Set the target pos only after it's completed its animation to the new position.
-        // This animation allows the eyes to settle on the new target position before we
-        // send the landmarks and target to the model trainer
-        targetElement.onReachedNewPosition(() => {
-            this_.target_pos = this_.next_target_pos
-        });
-
-        this.containerDiv = ui.vidCapContainer;
-        this.overlayCanvas = ui.overlayCanvas;
-        this.overlayCtx = this.overlayCanvas.getContext("2d") as CanvasRenderingContext2D;
-        // Append in this order for z-order (gaze above target)
-        document.documentElement.appendChild(targetElement);
-        document.documentElement.appendChild(gazeElement);
-
-
-        this.targetElement = targetElement;
-
-        let current_x = 0;
-        let current_y = 0;
-        this.on('GazeDetectionComplete', (features: iGazeDetectorAddDataResult) => {
-
-            gazeElement.setPosition(features.gaze);
-
-            let rx = features.losses.h_loss * screen.width;
-            let ry = features.losses.v_loss * screen.height;
-
-            // Don't allow the target ellipse to be too big (if the loss is big) or too small
-            rx = rx.clamp(15, 100);
-            ry = ry.clamp(15, 100);
-
-
-            targetElement.setRadius(rx, ry);
-            targetElement.setCaption(`<div>${features.data_index}</div>`)
-
-        });
-
-        // Landmark selector
-        if (landmarkSelectorElement) {
-            const GroupsElement = <HTMLDivElement>landmarkSelectorElement.children[0];
-            const CheckboxesElement = <HTMLDivElement>landmarkSelectorElement.children[1];
-            const displayLandmarkArray = this.displayLandmarkArray;
-            for (let i = 0; i < 478; ++i) {
-                const checkBoxEl = document.createElement('input');
-                checkBoxEl.type = 'checkbox';
-                checkBoxEl.title = '' + i;
-                // mouse pointer changes to crosshair when hovering over checkbox
-                checkBoxEl.style.cursor = 'crosshair';
-                displayLandmarkArray.push({color: '#ffffff', visible: false});
-                checkBoxEl.addEventListener('click', (evt) => {
-                    const el = <HTMLInputElement>evt.target;
-                    displayLandmarkArray[Number.parseInt(el.title)].visible = el.checked;
-                })
-                checkBoxEl.addEventListener('mouseenter', (evt) => {
-                    const el = <HTMLInputElement>evt.target;
-                    displayLandmarkArray[Number.parseInt(el.title)].visible = true;
-                })
-
-                checkBoxEl.addEventListener('mouseleave', (evt) => {
-                    const el = <HTMLInputElement>evt.target;
-                    displayLandmarkArray[Number.parseInt(el.title)].visible = el.checked;
-                })
-                CheckboxesElement.appendChild(checkBoxEl);
-            }
-
-            const myConnections = [];
-            const r1 = [127, 162, 21, 54, 103, 67, 109, 10, 338, 297, 332, 284, 251, 389,356,];
-            const r2 = [246, 161, 160, 159, 158, 157, 173, 8, 398, 384, 385, 385, 387, 388, 466,];
-            const r3 = [33, 468, 133, 168, 362, 473, 263,];
-            const r4 = [7, 163, 144, 145, 153, 154, 155, 6, 382, 381, 380, 374, 373, 390, 249,];
-            const r5 = [132, 147, 187, 207, 206, 165, 167, 164, 393, 391, 426, 427, 411, 376, 361,];
-            for (const lms of [
-                {connections: [], indexes:  [127, 162, 21, 54, 103, 67, 109, 10, 338, 297, 332, 284, 251, 389,356,], color: '#ffffff', name: 'l2s_r1'},
-                {connections: [], indexes:  [246, 161, 160, 159, 158, 157, 173, 8, 398, 384, 385, 386, 387, 388, 466,], color: '#ffffff', name: 'l2s_r2'},
-                {connections: [], indexes:  [33, 470, 471, 468, 469, 472, 133, 168, 362, 477, 476, 473, 474, 475, 263,], color: '#ffffff', name: 'l2s_r3'},
-                {connections: [], indexes:  [7, 163, 144, 145, 153, 154, 155, 6, 382, 381, 380, 374, 373, 390, 249,], color: '#ffffff', name: 'l2s_r4'},
-                {connections: [], indexes:  [132, 147, 187, 207, 206, 165, 167, 164, 393, 391, 426, 427, 411, 376, 361,], color: '#ffffff', name: 'l2s_r5'},
-                {connections: FaceLandmarker.FACE_LANDMARKS_FACE_OVAL, indexes: [], color: '#800000', name: 'face-oval'},
-                {connections: FaceLandmarker.FACE_LANDMARKS_LEFT_EYE, indexes: [], color: '#0010ff', name: 'left-eye'},
-                {connections: FaceLandmarker.FACE_LANDMARKS_RIGHT_EYE, indexes: [], color: '#00507f', name: 'right-eye'},
-                {connections: FaceLandmarker.FACE_LANDMARKS_LEFT_EYEBROW, indexes: [], color: '#009f30', name: 'left-eyebrow'},
-                {connections: FaceLandmarker.FACE_LANDMARKS_RIGHT_EYEBROW, indexes: [], color: '#007f60', name: 'right-eyebrow'},
-                {connections: FaceLandmarker.FACE_LANDMARKS_LEFT_IRIS, indexes: [],color: '#ffff00', name: 'left-iris'},
-                {connections: FaceLandmarker.FACE_LANDMARKS_RIGHT_IRIS, indexes: [],color: '#8f8f00', name: 'right-iris'},
-                {connections: FaceLandmarker.FACE_LANDMARKS_LIPS, indexes: [],color: '#ff8de2', name: 'lips'},
-
-            ]) {
-                const groupCheckBoxEl = document.createElement('input');
-                const groupCheckBoxLabelEl = document.createElement('label');
-
-                groupCheckBoxLabelEl.appendChild(document.createTextNode(lms.name));
-
-                groupCheckBoxEl.type = 'checkbox';
-                groupCheckBoxEl.style.accentColor = lms.color;
-                groupCheckBoxLabelEl.appendChild(groupCheckBoxEl);
-                groupCheckBoxEl.addEventListener('click', (evt) => {
-                    const el = <HTMLInputElement>evt.target;
-                    for (const c of lms.connections) {
-                        const checkBoxEl = <HTMLInputElement>CheckboxesElement.children[c.start];
-                        checkBoxEl.checked = el.checked;
-                        checkBoxEl.style.accentColor = lms.color;
-                        displayLandmarkArray[c.start] = {visible: el.checked, color: lms.color};
-                    }
-                    for (const i of lms.indexes) {
-                        const checkBoxEl = <HTMLInputElement>CheckboxesElement.children[i];
-                        checkBoxEl.checked = el.checked;
-                        checkBoxEl.style.accentColor = lms.color;
-                        displayLandmarkArray[i] = {visible: el.checked, color: lms.color};
-                    }
-
-                })
-                GroupsElement.appendChild(groupCheckBoxLabelEl);
-
-                // for (const c of lms.connections) {
-                //     const checkBoxEl = <HTMLInputElement>CheckboxesElement.children[c.start];
-                //     checkBoxEl.checked = true;
-                //     checkBoxEl.style.accentColor = lms.color;
-                //     displayLandmarkArray[c.start] = { visible: true, color: lms.color};
-                // }
-            }
-
-        }
     }
 }
 

--- a/src/LandmarkRenderer.ts
+++ b/src/LandmarkRenderer.ts
@@ -1,0 +1,36 @@
+import {NormalizedLandmark} from "@mediapipe/tasks-vision";
+
+export interface LandmarkDisplayOption {
+    visible: boolean;
+    color: string;
+}
+
+/**
+ * Draws facial landmark overlays on a canvas using configurable display options
+ * for each landmark point.
+ */
+export class LandmarkRenderer {
+    private ctx: CanvasRenderingContext2D;
+    public displayLandmarkArray: LandmarkDisplayOption[] = [];
+
+    constructor(private canvas: HTMLCanvasElement) {
+        this.ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+    }
+
+    public render(landmarks: NormalizedLandmark[]): void {
+        const overlayCanvas = this.canvas;
+        const overlayCtx = this.ctx;
+        overlayCtx.clearRect(0, 0, 10000, 10000);
+        for (const [idx, point] of landmarks.entries()) {
+            const lms = this.displayLandmarkArray[idx];
+            if (lms?.visible) {
+                overlayCtx.fillStyle = lms.color;
+                overlayCtx.setTransform({a: -1, e: overlayCanvas.width});
+                overlayCtx.beginPath();
+                overlayCtx.arc(point.x * overlayCanvas.width, point.y * overlayCanvas.height, 2, 0, 2 * Math.PI);
+                overlayCtx.fill();
+            }
+        }
+    }
+}
+

--- a/src/SampleCollector.ts
+++ b/src/SampleCollector.ts
@@ -1,0 +1,36 @@
+import EventEmitter from "eventemitter3";
+import {Coord, screenToModelCoords} from "./util/Coords";
+import type {iGazeDetectorAddDataResult, IGazeTrainer} from "./training/Trainer";
+import {NormalizedLandmark} from "@mediapipe/tasks-vision";
+
+/**
+ * Packages landmark and target data and forwards samples to the trainer,
+ * re-emitting predictions as they arrive.
+ */
+export class SampleCollector extends EventEmitter {
+    private trainer: IGazeTrainer | undefined = undefined;
+
+    private onTrainerPrediction = (features: iGazeDetectorAddDataResult) => {
+        this.emit('prediction', features);
+    };
+
+    public set Trainer(t: IGazeTrainer | undefined) {
+        if (this.trainer) this.trainer.off('prediction', this.onTrainerPrediction);
+        this.trainer = t;
+        if (t) t.on('prediction', this.onTrainerPrediction);
+    }
+
+    public get Trainer(): IGazeTrainer | undefined {
+        return this.trainer;
+    }
+
+    public collect(landmarks: NormalizedLandmark[], target: Coord | undefined): void {
+        const landmarks_as_array = landmarks.map((p) => [p.x, p.y, p.z]);
+        const target_model = target ? screenToModelCoords(target) : null;
+        this.trainer?.addSample({
+            landmarks: landmarks_as_array,
+            target: target_model ? [target_model.x, target_model.y] : null,
+        });
+    }
+}
+

--- a/src/TargetManager.ts
+++ b/src/TargetManager.ts
@@ -1,0 +1,47 @@
+import EventEmitter from "eventemitter3";
+import {GazeElement} from "./GazeElement";
+import {Coord} from "./util/Coords";
+
+/**
+ * Controls the on‑screen training target, emitting updates as it moves and
+ * adjusting visual feedback based on trainer losses.
+ */
+export class TargetManager extends EventEmitter {
+    private target_pos: Coord | undefined = undefined;
+    private next_target_pos: Coord | undefined = undefined;
+    private targetElement: GazeElement;
+
+    constructor(targetElement: GazeElement) {
+        super();
+        this.targetElement = targetElement;
+        this.targetElement.onReachedNewPosition(() => {
+            this.target_pos = this.next_target_pos;
+            this.emit('targetUpdated', this.target_pos);
+        });
+    }
+
+    public set TargetPos(next_target_pos: Coord | undefined) {
+        if (next_target_pos === undefined) {
+            this.target_pos = undefined;
+        }
+        this.next_target_pos = this.targetElement.setPosition(next_target_pos);
+    }
+
+    public get TargetPos(): Coord | undefined {
+        return this.next_target_pos;
+    }
+
+    public get CurrentTarget(): Coord | undefined {
+        return this.target_pos;
+    }
+
+    public updateFeedback(features: {losses: {h_loss: number, v_loss: number}, data_index: number}): void {
+        let rx = features.losses.h_loss * screen.width;
+        let ry = features.losses.v_loss * screen.height;
+        rx = rx.clamp(15, 100);
+        ry = ry.clamp(15, 100);
+        this.targetElement.setRadius(rx, ry);
+        this.targetElement.setCaption(`<div>${features.data_index}</div>`);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Extract overlay drawing into new `LandmarkRenderer`
- Add `TargetManager` for training target movement and feedback
- Introduce `SampleCollector` to package data for trainer
- Streamline `GazeDetector` to orchestrate modules and video capture

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c5ae5d74f0832a8a047cbbe8c97ea5