### PR TITLE
Refactor gaze session to use services for input and acquisition

### DIFF
--- a/src/controllers/GazeSession.ts
+++ b/src/controllers/GazeSession.ts
@@ -3,7 +3,6 @@ import EventEmitter from "eventemitter3";
 import { GazeDetector } from "../GazeDetector";
 import { save_gaze_model } from "../apiService";
 import { ui } from "../UI";
-import { notifications } from "../services/NotificationService";
 import { Trainer, IGazeTrainer } from "../training/Trainer";
 
 export class GazeSession extends EventEmitter {
@@ -14,39 +13,13 @@ export class GazeSession extends EventEmitter {
     return this.isGazeDetectionActive;
   }
 
-  public get isDataAcquisitionActive(): boolean {
-    return this.gazeDetector !== undefined && this.gazeDetector.TargetPos !== undefined;
-  }
-
   public get isTrainingActive(): boolean {
     return this.trainer?.isTraining ?? false;
   }
 
-  private targetTimeMs = 5000;
-  public set TargetTimeMs(t: number) {
-    this.targetTimeMs = t;
-  }
-
   public gazeDetector?: GazeDetector;
 
-  private handleKeyboard = async (evt: KeyboardEvent) => {
-    if (evt.key === "s") {
-      notifications.notify("Saving model.");
-      const success = await this.SaveGazeDetectorModel();
-      notifications.notify(success ? "Saved model." : "Failed to save model.");
-    } else if (evt.key === " ") {
-      if (this.isDataAcquisitionActive) await this.StopDataAcquisition();
-      else await this.StartDataAcquisition();
-      notifications.notify(this.isDataAcquisitionActive ? "Data acquisition started." : "Data acquisition stopped.");
-    } else if (evt.key === "c") {
-      if (this.isTrainingActive) await this.StopTraining();
-      else await this.StartTraining();
-      notifications.notify(this.isTrainingActive ? "Calibration started." : "Calibration stopped.");
-    }
-  };
-
   public async Run() {
-    window.addEventListener("keyup", this.handleKeyboard);
     await this.StartGazeDetection();
   }
 
@@ -63,49 +36,6 @@ export class GazeSession extends EventEmitter {
     this.isGazeDetectionActive = false;
   }
 
-  public async StartDataAcquisition() {
-    const this_ = this;
-    const x_positions: number[] = [
-      0,
-      0,
-      0,
-      screen.width / 2 - 50,
-      screen.width / 2 - 50,
-      screen.width / 2 - 50,
-      screen.width / 2,
-      screen.width / 2 + 50,
-      screen.width,
-      screen.width,
-      screen.width,
-    ];
-    const y_positions: number[] = [0, 0, 0, 0 / 2 - 50, screen.height / 2, screen.height / 2 + 50, screen.height, screen.height, screen.height];
-
-    const center_x = screen.width / 2;
-    const center_y = screen.height / 2 - 250;
-
-    for (const offset of [-200, -100, 0, 0, 0, 100, 200]) {
-      x_positions.push(center_x + offset);
-      y_positions.push(center_y + offset);
-    }
-    const jitter = [-1, -2, -3, -4, 4, 3, 2, 1, 0];
-
-    if (this.gazeDetector) this.gazeDetector.TargetPos = { x: 0, y: 0 };
-
-    const new_pos = () => {
-      if (this.gazeDetector && this_.isGazeDetectionActive && this.gazeDetector.TargetPos) {
-        this.gazeDetector.TargetPos = {
-          x: x_positions.randomElement() + jitter.randomElement(),
-          y: y_positions.randomElement() + jitter.randomElement(),
-        };
-        setTimeout(new_pos, this_.targetTimeMs);
-      }
-    };
-    new_pos();
-  }
-
-  public async StopDataAcquisition() {
-    if (this.gazeDetector && this.isGazeDetectionActive) this.gazeDetector.TargetPos = undefined;
-  }
 
   public async SaveGazeDetectorModel(): Promise<boolean> {
     try {

--- a/src/services/DataAcquisitionService.ts
+++ b/src/services/DataAcquisitionService.ts
@@ -1,0 +1,73 @@
+import { GazeDetector } from "../GazeDetector";
+
+export class DataAcquisitionService {
+  private targetTimeMs = 5000;
+  private active = false;
+
+  constructor(private gazeDetector: GazeDetector) {}
+
+  public set TargetTimeMs(t: number) {
+    this.targetTimeMs = t;
+  }
+
+  public get isActive(): boolean {
+    return this.active && this.gazeDetector.TargetPos !== undefined;
+  }
+
+  public async start() {
+    if (this.active) return;
+    this.active = true;
+
+    const x_positions: number[] = [
+      0,
+      0,
+      0,
+      screen.width / 2 - 50,
+      screen.width / 2 - 50,
+      screen.width / 2 - 50,
+      screen.width / 2,
+      screen.width / 2 + 50,
+      screen.width,
+      screen.width,
+      screen.width,
+    ];
+    const y_positions: number[] = [
+      0,
+      0,
+      0,
+      0 / 2 - 50,
+      screen.height / 2,
+      screen.height / 2 + 50,
+      screen.height,
+      screen.height,
+      screen.height,
+    ];
+
+    const center_x = screen.width / 2;
+    const center_y = screen.height / 2 - 250;
+
+    for (const offset of [-200, -100, 0, 0, 0, 100, 200]) {
+      x_positions.push(center_x + offset);
+      y_positions.push(center_y + offset);
+    }
+    const jitter = [-1, -2, -3, -4, 4, 3, 2, 1, 0];
+
+    this.gazeDetector.TargetPos = { x: 0, y: 0 };
+
+    const new_pos = () => {
+      if (this.active && this.gazeDetector.TargetPos) {
+        this.gazeDetector.TargetPos = {
+          x: x_positions.randomElement() + jitter.randomElement(),
+          y: y_positions.randomElement() + jitter.randomElement(),
+        };
+        setTimeout(new_pos, this.targetTimeMs);
+      }
+    };
+    new_pos();
+  }
+
+  public async stop() {
+    this.active = false;
+    this.gazeDetector.TargetPos = undefined;
+  }
+}

--- a/src/services/InputHandler.ts
+++ b/src/services/InputHandler.ts
@@ -1,0 +1,40 @@
+import { GazeSession } from "../controllers/GazeSession";
+import { DataAcquisitionService } from "./DataAcquisitionService";
+import { notifications } from "./NotificationService";
+
+export class InputHandler {
+  constructor(
+    private session: GazeSession,
+    private dataAcquisition: DataAcquisitionService
+  ) {
+    window.addEventListener("keyup", this.handleKeyboard);
+  }
+
+  private handleKeyboard = async (evt: KeyboardEvent) => {
+    if (evt.key === "s") {
+      notifications.notify("Saving model.");
+      const success = await this.session.SaveGazeDetectorModel();
+      notifications.notify(success ? "Saved model." : "Failed to save model.");
+    } else if (evt.key === " ") {
+      if (this.dataAcquisition.isActive) await this.dataAcquisition.stop();
+      else await this.dataAcquisition.start();
+      notifications.notify(
+        this.dataAcquisition.isActive
+          ? "Data acquisition started."
+          : "Data acquisition stopped."
+      );
+    } else if (evt.key === "c") {
+      if (this.session.isTrainingActive) await this.session.StopTraining();
+      else await this.session.StartTraining();
+      notifications.notify(
+        this.session.isTrainingActive
+          ? "Calibration started."
+          : "Calibration stopped."
+      );
+    }
+  };
+
+  public dispose() {
+    window.removeEventListener("keyup", this.handleKeyboard);
+  }
+}


### PR DESCRIPTION
## Summary
- Delegate keyboard shortcuts to a new InputHandler service
- Extract target sequencing into DataAcquisitionService
- Simplify GazeSession to lifecycle management and wire new services in index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5bf256e58832a8896351aeae9ad88