### PR TITLE
Remove server-side training routes and document client-side training

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
-1.  Download GitHub Repo
+# L2S
 
-### Run Locally ###
- 1. Create python env (see install_python_env.sh)
- 2. Ensure you have latest version of npm installed
- 3. npm install
- 4. Run the server (see run.sh)
- 5. Point browser at localhost:5000
+This repository provides a lightweight Flask server that delivers the web
+client for the Learn2See project.
 
-## Or Run 
+## Run Locally
+
+1. Create a Python environment (see `install_python_env.sh`).
+2. Ensure you have the latest version of npm installed.
+3. `npm install`
+4. Run the server (see `run.sh`).
+5. Point a browser at <http://localhost:5000>.
+
+## Architecture
+
+Model training and calibration now occur entirely in the client. The Flask
+application serves only static files and, optionally, pre-trained models. Any
+model files placed in `cache/checkpoints` can be downloaded via
+`/models/<filename>`.
+


### PR DESCRIPTION
## Summary
- Simplify Flask app to only serve static files and allow optional download of pre-trained models.
- Document new client-side training architecture and server responsibilities.

## Testing
- `python -m py_compile app.py`
- `npm test` *(vitest – 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c2adedf0832a854507b327ff4832