### PR TITLE
fix wasm path

### DIFF
--- a/src/runtime/WebOnnxAdapter.ts
+++ b/src/runtime/WebOnnxAdapter.ts
@@ -15,8 +15,9 @@ export class WebOnnxAdapter {
     env.wasm.simd = true;
     env.wasm.numThreads = 4;
     env.wasm.proxy = true;
-    // ORT expects its wasm assets relative to this path
-    env.wasm.wasmPaths = '/ort';
+    // ORT expects its wasm assets relative to this path.
+    // The Vite build copies the WASM binaries into /assets.
+    env.wasm.wasmPaths = '/assets';
 
     const sessionOptions: ort.InferenceSession.SessionOptions = {
       executionProviders: ['webgpu', 'wasm'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,7 +49,12 @@ export default defineConfig({
           src: '../static/**/*',
           dest: '.' // copies all files from static to dist/static/
         },
-        { src: '../node_modules/onnxruntime-web/dist/*', dest: 'ort' }
+        {
+          // Ensure ONNX Runtime's WASM binaries are available under /assets/
+          // so that the application can load them via absolute URLs.
+          src: '../node_modules/onnxruntime-web/dist/*.wasm',
+          dest: 'assets'
+        }
       ]
     })
   ]


### PR DESCRIPTION
## Summary
- copy ONNX Runtime wasm binaries into the build's `/assets` directory
- configure WebOnnxAdapter to load wasm assets from `/assets`

## Testing
- `npm run build`
- `python dist/app.py &` *(fails: port already in use first time, run after killing old process)*
- `curl -I http://localhost:5000/assets/ort-wasm-simd-threaded.jsep.wasm`


------
https://chatgpt.com/codex/tasks/task_e_68c5d121a768832a912f06c6cc8248cc