### PR TITLE
Add type declarations for ONNX TrainingSession

### DIFF
--- a/src/onnxruntime-training.d.ts
+++ b/src/onnxruntime-training.d.ts
@@ -1,0 +1,18 @@
+import type { Tensor } from 'onnxruntime-common';
+
+export interface TrainingArtifacts {
+  train: ArrayBuffer;
+  eval: ArrayBuffer;
+  optimizer: ArrayBuffer;
+  init: ArrayBuffer;
+}
+
+declare module 'onnxruntime-web' {
+  export { TrainingArtifacts };
+  export class TrainingSession {
+    static create(artifacts: TrainingArtifacts): Promise<TrainingSession>;
+    trainStep(inputs: Tensor[]): Promise<void>;
+    optimizerStep(): Promise<void>;
+    lazyResetGrad(): Promise<void>;
+  }
+}


### PR DESCRIPTION
## Summary
- add module augmentation for `onnxruntime-web` to expose `TrainingSession` and training artifact types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c69b52e938832a80f5d560d91f1d83