### PR TITLE
feat: batch PCA training

### DIFF
--- a/scripts/sklearn_pca.py
+++ b/scripts/sklearn_pca.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import json, sys
+import numpy as np
+from sklearn.decomposition import PCA
+
+def main():
+    data = json.load(sys.stdin)
+    landmarks = np.array(data['landmarks'], dtype=np.float32)
+    sample_count = len(landmarks) // (478 * 3)
+    landmarks = landmarks.reshape(sample_count, 478 * 3)
+    pca = PCA(n_components=32)
+    features = pca.fit_transform(landmarks)
+    total_var = float(np.var(landmarks, axis=0, ddof=1).sum())
+    out = {
+        'features': features.flatten().tolist(),
+        'total_var': total_var,
+    }
+    json.dump(out, sys.stdout)
+
+if __name__ == '__main__':
+    main()

--- a/src/runtime/TrainableOnnx.test.ts
+++ b/src/runtime/TrainableOnnx.test.ts
@@ -1,7 +1,33 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
+
+vi.mock('onnxruntime-web', () => ({
+  Tensor: class {
+    constructor(public type: string, public data: Float32Array, public dims: number[]) {}
+  }
+}));
+
 import { TrainableOnnxAdapter } from './TrainableOnnx';
 
-test('TrainableOnnxAdapter exposes init', () => {
+test('TrainableOnnxAdapter exposes init and supports batched PCA training', async () => {
   const t = new TrainableOnnxAdapter();
   expect(typeof t.init).toBe('function');
+
+  const trainStep = vi.fn();
+  const optimizerStep = vi.fn();
+  const lazyResetGrad = vi.fn();
+  const evalStep = vi.fn(async () => [{ data: new Float32Array(32) }]);
+
+  // inject fake trainer so we can call trainPca without loading real artifacts
+  (t as any).pcaTrainer = { trainStep, optimizerStep, lazyResetGrad, evalStep };
+
+  const landmarks = new Float32Array(2 * 478 * 3); // two samples
+  const targets = new Float32Array(2 * 32);
+
+  await t.trainPca(landmarks, targets, 1);
+  expect(trainStep).toHaveBeenCalledTimes(2);
+  expect(optimizerStep).toHaveBeenCalledTimes(1);
+  expect(lazyResetGrad).toHaveBeenCalledTimes(1);
+
+  const out = await t.transformPca(landmarks.subarray(0, 478 * 3), 1);
+  expect(out).toBeInstanceOf(Float32Array);
 });

--- a/src/runtime/pcaHarness.test.ts
+++ b/src/runtime/pcaHarness.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest';
+
+const run = process.env.RUN_PCA_COMPARE === '1';
+
+(run ? test : test.skip)(
+  'PCA training matches sklearn variance ratios',
+  async () => {
+    const { compareWithSklearn } = await import('./pcaHarness');
+    const { skVariance, onnxVariance } = await compareWithSklearn(64);
+    skVariance.forEach((v, i) => {
+      expect(onnxVariance[i]).toBeCloseTo(v, 4);
+    });
+  },
+);

--- a/src/runtime/pcaHarness.ts
+++ b/src/runtime/pcaHarness.ts
@@ -1,0 +1,80 @@
+// src/runtime/pcaHarness.ts
+// Generate a synthetic dataset, train the PCA ONNX model, and compare
+// explained variance ratios against sklearn's PCA implementation.
+
+import { spawnSync } from 'child_process';
+import { trainableOnnx } from './TrainableOnnx';
+
+function varianceRatios(
+  features: Float32Array,
+  featureSize: number,
+  totalVariance?: number,
+): number[] {
+  const sampleCount = features.length / featureSize;
+  const means = new Float64Array(featureSize);
+  for (let i = 0; i < sampleCount; i++) {
+    for (let j = 0; j < featureSize; j++) {
+      means[j] += features[i * featureSize + j];
+    }
+  }
+  for (let j = 0; j < featureSize; j++) {
+    means[j] /= sampleCount;
+  }
+
+  const variances = new Float64Array(featureSize);
+  for (let i = 0; i < sampleCount; i++) {
+    for (let j = 0; j < featureSize; j++) {
+      const d = features[i * featureSize + j] - means[j];
+      variances[j] += d * d;
+    }
+  }
+  for (let j = 0; j < featureSize; j++) {
+    variances[j] /= (sampleCount - 1);
+  }
+  const denom = totalVariance ?? variances.reduce((a, b) => a + b, 0);
+  return Array.from(variances, v => v / denom);
+}
+
+function fakeLandmarks(sampleCount: number): Float32Array {
+  const arr = new Float32Array(sampleCount * 478 * 3);
+  for (let i = 0; i < arr.length; i++) arr[i] = Math.random();
+  return arr;
+}
+
+function runSklearn(landmarks: Float32Array) {
+  const proc = spawnSync('python3', ['scripts/sklearn_pca.py'], {
+    input: JSON.stringify({ landmarks: Array.from(landmarks) }),
+    encoding: 'utf-8',
+  });
+  if (proc.status !== 0) {
+    throw new Error(proc.stderr || 'failed to run sklearn_pca.py');
+  }
+  const out = JSON.parse(proc.stdout);
+  return {
+    features: new Float32Array(out.features),
+    totalVar: out.total_var as number,
+  };
+}
+
+export async function compareWithSklearn(sampleCount = 64) {
+  const landmarks = fakeLandmarks(sampleCount);
+  const { features, totalVar } = runSklearn(landmarks);
+
+  await trainableOnnx.init();
+  await trainableOnnx.trainPca(landmarks, features, sampleCount);
+  const transformed = await trainableOnnx.transformPca(landmarks, sampleCount);
+  const skVariance = varianceRatios(features, 32, totalVar);
+  const onnxVariance = varianceRatios(transformed, 32, totalVar);
+
+  return { skVariance, onnxVariance };
+}
+
+if (import.meta.main) {
+  compareWithSklearn().then(({ skVariance, onnxVariance }) => {
+    console.log('sklearn', skVariance);
+    console.log('onnx', onnxVariance);
+  }).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- allow PCA model to train on batched landmark and label arrays
- expose transformPca to retrieve PCA features for comparison with sklearn
- add harness + python utility to compare PCA variance ratios with sklearn
- gracefully handle missing ORT artifacts so comparison test can run in Node

## Testing
- `RUN_PCA_COMPARE=1 npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c6a2136250832a8ede806882186eeb