### PR TITLE
feat(runtime): add batched MLP training

### DIFF
--- a/scripts/trainMlpBatchDemo.ts
+++ b/scripts/trainMlpBatchDemo.ts
@@ -1,0 +1,18 @@
+import { TrainableOnnxAdapter } from '../src/runtime/TrainableOnnx';
+
+async function main() {
+  const adapter = new TrainableOnnxAdapter();
+  await adapter.init();
+
+  // Example recorded features and targets. Each feature vector has 32 elements
+  // and each target has 2 elements. Replace with real data as needed.
+  const features = new Float32Array(Array.from({ length: 64 }, (_, i) => i / 100));
+  const targets = new Float32Array([0, 0, 1, 1]);
+
+  const losses = await adapter.trainMlpBatch(features, targets, 1, 3);
+  losses.forEach((loss, epoch) => {
+    console.log(`Epoch ${epoch + 1}: loss=${loss}`);
+  });
+}
+
+main().catch(err => console.error(err));

--- a/src/onnxruntime-training.d.ts
+++ b/src/onnxruntime-training.d.ts
@@ -11,7 +11,8 @@ declare module 'onnxruntime-web' {
   export { TrainingArtifacts };
   export class TrainingSession {
     static create(artifacts: TrainingArtifacts): Promise<TrainingSession>;
-    trainStep(inputs: Tensor[]): Promise<void>;
+    // trainStep may return output tensors such as the loss value.
+    trainStep(inputs: Tensor[]): Promise<Tensor[]>;
     optimizerStep(): Promise<void>;
     lazyResetGrad(): Promise<void>;
   }


### PR DESCRIPTION
## Summary
- support retrieving loss tensor from trainStep
- add trainMlpBatch with per-epoch average loss
- include demo script for batch MLP training

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6b316defc832aa1054572c357e555