### PR TITLE
Refactor training dataset capacity constant

### DIFF
--- a/src/training/Trainer.ts
+++ b/src/training/Trainer.ts
@@ -46,8 +46,8 @@ class RingBufferDataset<T> {
 }
 
 export class Trainer extends EventEmitter implements IGazeTrainer {
-    private readonly MAX_BACKLOG_ITEMS = 30; // ~1s of data @30fps
-    private dataset = new RingBufferDataset<BatchItem>(this.MAX_BACKLOG_ITEMS);
+    private readonly DATASET_CAPACITY = 2048; // maximum number of samples to retain
+    private dataset = new RingBufferDataset<BatchItem>(this.DATASET_CAPACITY);
     private trainingActive = false;
     private trainingLoop?: Promise<void>;
 


### PR DESCRIPTION
## Summary
- Rename backlog constant to `DATASET_CAPACITY` and increase capacity to 2048 samples
- Document dataset capacity and initialize `RingBufferDataset` with new constant

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c6cca445cc832ab30297f37e27e593