### PR TITLE
feat: persist and load gaze model

### DIFF
--- a/src/apiService.test.ts
+++ b/src/apiService.test.ts
@@ -5,8 +5,18 @@ vi.mock("./runtime/WebOnnxAdapter", () => {
         webOnnx: {
             ready: true,
             predict: vi.fn().mockResolvedValue([1, 2]),
+            exportMlpModel: vi.fn().mockResolvedValue(new ArrayBuffer(4)),
         },
     };
+});
+
+const localStore: Record<string, string> = {};
+// @ts-ignore
+vi.stubGlobal("localStorage", {
+    getItem: (k: string) => (k in localStore ? localStore[k] : null),
+    setItem: (k: string, v: string) => {
+        localStore[k] = v;
+    },
 });
 
 import { apiAvailable, post_data, train, save_gaze_model } from "./apiService";

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { DataAcquisitionService } from "./services/DataAcquisitionService";
 
 import "./util/index";
 import { TabNavigator } from "./util/nav";
-import { apiAvailable } from "./apiService";
+import { apiAvailable, getSavedGazeModel } from "./apiService";
 import { Fullscreen } from "./util/util";
 import { webOnnx } from "./runtime/WebOnnxAdapter";
 import { PixelCoord } from "./util/Coords";
@@ -55,7 +55,7 @@ function monitorApiStatus() {
 }
 
 export async function bootstrap() {
-    await webOnnx.init();
+    await webOnnx.init(getSavedGazeModel() ?? undefined);
     await webOnnx.predict(Array.from({ length: 478 }, () => [0, 0, 0] as PixelCoord));
     initUI();
     monitorApiStatus();


### PR DESCRIPTION
## Summary
- save current gaze MLP weights and bias to a downloadable JSON and localStorage
- load stored weights on startup with fallback to bundled models
- expose MLP export and allow passing saved weights into runtime init

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68c6cf49d1bc832ab6d9ef0d1626aa45