### PR TITLE
Enable real-time gaze predictions outside training

### DIFF
--- a/src/training/Trainer.ts
+++ b/src/training/Trainer.ts
@@ -78,19 +78,19 @@ export class Trainer extends EventEmitter implements IGazeTrainer {
 
     addSample(item: BatchItem) {
         this.dataset.add(item);
+        void post_data([item]).then((features) => {
+            if (features) {
+                this.emit('prediction', features);
+            }
+        });
     }
 
     private async runTrainingLoop() {
         while (this.trainingActive) {
             const batch = this.dataset.toArray();
-            const last = this.dataset.last;
-            if (batch.length && last) {
+            if (batch.length) {
                 const losses = await train(batch, 1, "train");
                 this.emit('loss', losses);
-                const features = await post_data([last]);
-                if (features) {
-                    this.emit('prediction', features);
-                }
                 this.epochCounter++;
                 this.emit('epoch', this.epochCounter);
             }


### PR DESCRIPTION
## Summary
- Emit prediction updates on every new sample, regardless of training state.
- Simplify training loop to focus on loss and epoch updates.

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6d41461f8832a930a13e2fd9c41c3