### PR TITLE
Add training progress bar and loss plotting

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,11 @@
             </div>
         </div>
         <div class="page" id="page-training" title="Training">
-            <!-- TODO Training loss plotting and progress bar -->
+            <div class="progress-container">
+                <progress id="trainingProgress" value="0" max="1"></progress>
+                <div class="losses">H: <span id="hLoss">0</span> V: <span id="vLoss">0</span> Loss: <span id="loss">0</span></div>
+            </div>
+            <canvas id="lossPlot" width="400" height="200"></canvas>
         </div>
     </main>
 </div>

--- a/src/controllers/GazeSession.ts
+++ b/src/controllers/GazeSession.ts
@@ -4,6 +4,7 @@ import { GazeDetector } from "../GazeDetector";
 import { save_gaze_model } from "../apiService";
 import { ui } from "../UI";
 import { Trainer, IGazeTrainer } from "../training/Trainer";
+import { trainingPage } from "./TrainingPage";
 
 export class GazeSession extends EventEmitter {
   private isGazeDetectionActive = false;
@@ -34,6 +35,7 @@ export class GazeSession extends EventEmitter {
       this.gazeDetector = undefined;
     }
     this.trainer = undefined;
+    trainingPage?.setTrainer(undefined);
     this.isGazeDetectionActive = false;
   }
 
@@ -69,6 +71,7 @@ export class GazeSession extends EventEmitter {
       });
     }
     this.gazeDetector.Trainer = this.trainer;
+    trainingPage?.setTrainer(this.trainer);
 
     const vidcap_overlay = ui.vidCapOverlay;
 

--- a/src/controllers/TrainingPage.ts
+++ b/src/controllers/TrainingPage.ts
@@ -1,0 +1,75 @@
+import type { IGazeTrainer, iGazeDetectorTrainResult } from "../training/Trainer";
+
+class TrainingPage {
+    private progressBar: HTMLProgressElement;
+    private hLossSpan: HTMLSpanElement;
+    private vLossSpan: HTMLSpanElement;
+    private lossSpan: HTMLSpanElement;
+    private canvas: HTMLCanvasElement;
+    private ctx: CanvasRenderingContext2D;
+    private lossHistory: number[] = [];
+    private trainer?: IGazeTrainer;
+
+    constructor() {
+        this.progressBar = document.getElementById('trainingProgress') as HTMLProgressElement;
+        this.hLossSpan = document.getElementById('hLoss') as HTMLSpanElement;
+        this.vLossSpan = document.getElementById('vLoss') as HTMLSpanElement;
+        this.lossSpan = document.getElementById('loss') as HTMLSpanElement;
+        this.canvas = document.getElementById('lossPlot') as HTMLCanvasElement;
+        const ctx = this.canvas.getContext('2d');
+        if (!ctx) throw new Error('No 2D context for loss plot');
+        this.ctx = ctx;
+    }
+
+    public setTrainer(t?: IGazeTrainer) {
+        if (this.trainer) {
+            this.trainer.off('epoch-start', this.onEpochStart);
+            this.trainer.off('progress', this.onProgress);
+            this.trainer.off('loss', this.onLoss);
+        }
+        this.trainer = t;
+        if (this.trainer) {
+            this.trainer.on('epoch-start', this.onEpochStart);
+            this.trainer.on('progress', this.onProgress);
+            this.trainer.on('loss', this.onLoss);
+        }
+    }
+
+    private onEpochStart = ({ total }: { total: number }) => {
+        this.progressBar.max = total;
+        this.progressBar.value = 0;
+    };
+
+    private onProgress = ({ current, losses }: { current: number; losses: iGazeDetectorTrainResult }) => {
+        this.progressBar.value = current;
+        this.hLossSpan.innerText = losses.h_loss.toFixed(3);
+        this.vLossSpan.innerText = losses.v_loss.toFixed(3);
+        this.lossSpan.innerText = losses.loss.toFixed(3);
+    };
+
+    private onLoss = (losses: iGazeDetectorTrainResult) => {
+        this.lossHistory.push(losses.loss);
+        this.drawPlot();
+    };
+
+    private drawPlot() {
+        const ctx = this.ctx;
+        const w = this.canvas.width;
+        const h = this.canvas.height;
+        ctx.clearRect(0, 0, w, h);
+        if (this.lossHistory.length < 2) return;
+        const maxLoss = Math.max(...this.lossHistory);
+        ctx.beginPath();
+        for (let i = 0; i < this.lossHistory.length; i++) {
+            const x = (i / (this.lossHistory.length - 1)) * w;
+            const y = h - (this.lossHistory[i] / maxLoss) * h;
+            if (i === 0) ctx.moveTo(x, y);
+            else ctx.lineTo(x, y);
+        }
+        ctx.strokeStyle = '#03ff10';
+        ctx.stroke();
+    }
+}
+
+export const trainingPage: TrainingPage | undefined =
+    typeof document !== 'undefined' ? new TrainingPage() : undefined;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -169,3 +169,20 @@
         .landmark_selector .checkboxes {
             grid-area: checkboxes;
         }
+
+        #page-training {
+            padding: 10px;
+        }
+
+        #trainingProgress {
+            width: 100%;
+            height: 20px;
+        }
+
+        #lossPlot {
+            width: 100%;
+            height: 200px;
+            border: 1px solid var(--page-border-color);
+            display: block;
+            margin-top: 10px;
+        }


### PR DESCRIPTION
## Summary
- Add training page with progress bar and loss plot
- Emit training progress events and average losses per epoch
- Wire training UI to trainer lifecycle and style training page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6e154c290832a8617b3b159e6d4a5