### PR TITLE
Implement batched training and enforce non-null targets

### DIFF
--- a/src/SampleCollector.ts
+++ b/src/SampleCollector.ts
@@ -25,11 +25,12 @@ export class SampleCollector extends EventEmitter {
     }
 
     public collect(landmarks: NormalizedLandmark[], target: Coord | undefined): void {
+        if (!target) return;
         const landmarks_as_array: PixelCoord[] = landmarks.map((p) => [p.x, p.y, p.z]);
-        const target_model = target ? screenToModelCoords(target) : null;
+        const target_model = screenToModelCoords(target);
         this.trainer?.addSample({
             landmarks: landmarks_as_array,
-            target: target_model ? [target_model.x, target_model.y] : null,
+            target: [target_model.x, target_model.y],
         });
     }
 }

--- a/src/apiService.ts
+++ b/src/apiService.ts
@@ -82,7 +82,6 @@ export async function train(
 
     for (let e = 0; e < epochs; e++) {
         for (const item of batch) {
-            if (!item.target) continue;
             const [gx0, gy0] = await webOnnx.predict(item.landmarks);
             const gx = gx0 + modelBias[0];
             const gy = gy0 + modelBias[1];
@@ -115,7 +114,7 @@ export async function post_data(
     const [gx0, gy0] = await webOnnx.predict(last.landmarks);
     const gx = gx0 + modelBias[0];
     const gy = gy0 + modelBias[1];
-    const [tx, ty] = last.target ?? [0, 0];
+    const [tx, ty] = last.target;
     const h_loss = Math.abs(gx - tx);
     const v_loss = Math.abs(gy - ty);
     const loss = (h_loss + v_loss) / 2;


### PR DESCRIPTION
## Summary
- Require a target gaze coordinate for every dataset entry and skip collection when missing
- Add batched training loop (default batch size 64) that iterates over dataset in mini-batches and tracks progress
- Remove null-target handling in training and prediction APIs

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c6ea1504f8832aa7a5c7be0048e034