### PR TITLE
Support batched gaze prediction and training

### DIFF
--- a/src/GazeDetector.ts
+++ b/src/GazeDetector.ts
@@ -57,7 +57,9 @@ export class GazeDetector extends EventEmitter {
         this.sampleCollector = new SampleCollector();
 
         this.sampleCollector.on('prediction', (features: iGazeDetectorAddDataResult) => {
-            this.training_loss = features.losses.loss;
+            if (features.losses.loss) {
+                this.training_loss = features.losses.loss;
+            }
             features.gaze = modelToScreenCoords(features.gaze);
             this.emit('GazeDetectionComplete', features);
         });

--- a/src/apiService.test.ts
+++ b/src/apiService.test.ts
@@ -4,7 +4,7 @@ vi.mock("./runtime/WebOnnxAdapter", () => {
     return {
         webOnnx: {
             ready: true,
-            predict: vi.fn().mockResolvedValue([1, 2]),
+            predict: vi.fn().mockResolvedValue([[1, 2]]),
             exportMlpModel: vi.fn().mockResolvedValue(new ArrayBuffer(4)),
         },
     };
@@ -38,7 +38,7 @@ describe("apiService", () => {
         const sample: BatchItem = { landmarks, target: [3, 4] };
         const fetchSpy = vi.fn();
         (globalThis as any).fetch = fetchSpy;
-        const result = await post_data([sample]);
+        const result = await post_data(sample);
         expect(result).toBeDefined();
         expect(result?.gaze).toEqual({ x: 1, y: 2 });
         expect(result?.losses).toEqual({ h_loss: 2, v_loss: 2, loss: 2 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ function monitorApiStatus() {
 
 export async function bootstrap() {
     await webOnnx.init(getSavedGazeModel() ?? undefined);
-    await webOnnx.predict(Array.from({ length: 478 }, () => [0, 0, 0] as PixelCoord));
+    await webOnnx.predict([Array.from({ length: 478 }, () => [0, 0, 0] as PixelCoord)]);
     initUI();
     monitorApiStatus();
 }

--- a/src/training/Trainer.ts
+++ b/src/training/Trainer.ts
@@ -1,6 +1,6 @@
 import EventEmitter from "eventemitter3";
 
-import { post_data, train } from "../apiService";
+import { train } from "../apiService";
 import { Coord, PixelCoord } from "../util/Coords";
 
 export interface iGazeDetectorTrainResult {
@@ -17,7 +17,7 @@ export interface iGazeDetectorAddDataResult {
 
 export type BatchItem = {
     landmarks: PixelCoord[];   // [[x,y,z], ...]
-    target: [number, number];   // screen-space target coordinates
+    target?: [number, number];   // screen-space target coordinates
 };
 
 export interface IGazeTrainer extends EventEmitter {
@@ -84,11 +84,6 @@ export class Trainer extends EventEmitter implements IGazeTrainer {
         // Ensure that only valid samples with a target are stored.
         if (!item.target) return;
         this.dataset.add(item);
-        void post_data([item]).then((features) => {
-            if (features) {
-                this.emit('prediction', features);
-            }
-        });
     }
 
     private readonly BATCH_SIZE = 64;


### PR DESCRIPTION
## Summary
- Allow WebOnnxAdapter.predict to process landmark batches and add batching smoke test
- Rework training and data paths to send batches through the model and emit predictions separately
- Always predict each frame while collecting data asynchronously

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6f7e82604832a9e2b91a06c57b6e2