### PR TITLE
Adjust artifact paths for TrainableOnnx

### DIFF
--- a/src/runtime/TrainableOnnx.ts
+++ b/src/runtime/TrainableOnnx.ts
@@ -10,12 +10,12 @@ interface ArtifactPaths {
 }
 
 async function fetchArtifacts(prefix: string): Promise<ArtifactPaths> {
-  const base = `/ort/${prefix}`;
+  const base = '/models/ort_artifacts/' + prefix;
   const [train, evalModel, optimizer, init] = await Promise.all([
-    fetch(`${base}training_model.onnx`).then(r => r.arrayBuffer()),
-    fetch(`${base}eval_model.onnx`).then(r => r.arrayBuffer()),
-    fetch(`${base}optimizer.onnx`).then(r => r.arrayBuffer()),
-    fetch(`${base}checkpoint.onnx`).then(r => r.arrayBuffer()),
+    fetch(base + 'training_model.onnx').then(r => r.arrayBuffer()),
+    fetch(base + 'eval_model.onnx').then(r => r.arrayBuffer()),
+    fetch(base + 'optimizer.onnx').then(r => r.arrayBuffer()),
+    fetch(base + 'checkpoint.onnx').then(r => r.arrayBuffer()),
   ]);
   return { train, eval: evalModel, optimizer, init };
 }


### PR DESCRIPTION
## Summary
- refactor TrainableOnnx artifact fetch to use `/models/ort_artifacts/<prefix>`
- verify adapter loads artifacts from new models path

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c717759f44832a8bfe68cb42458823