### PR TITLE
Use ONNX batch training for gaze model

### DIFF
--- a/scripts/trainMlpBatchDemo.ts
+++ b/scripts/trainMlpBatchDemo.ts
@@ -9,7 +9,7 @@ async function main() {
   const features = new Float32Array(Array.from({ length: 64 }, (_, i) => i / 100));
   const targets = new Float32Array([0, 0, 1, 1]);
 
-  const losses = await adapter.trainMlpBatch(features, targets, 1, 3);
+  const losses = await adapter.trainMlpBatch(features, targets, 1, 3, 0.01);
   losses.forEach((loss, epoch) => {
     console.log(`Epoch ${epoch + 1}: loss=${loss}`);
   });

--- a/src/apiService.test.ts
+++ b/src/apiService.test.ts
@@ -6,6 +6,17 @@ vi.mock("./runtime/WebOnnxAdapter", () => {
             ready: true,
             predict: vi.fn().mockResolvedValue([[1, 2]]),
             exportMlpModel: vi.fn().mockResolvedValue(new ArrayBuffer(4)),
+            init: vi.fn().mockResolvedValue(undefined),
+        },
+    };
+});
+
+vi.mock("./runtime/TrainableOnnx", () => {
+    return {
+        trainableOnnx: {
+            transformPca: vi.fn(async (_l: Float32Array, batch: number) => new Float32Array(batch * 32)),
+            trainMlpBatch: vi.fn(async () => [0.1]),
+            exportMlpModel: vi.fn(async () => new ArrayBuffer(4)),
         },
     };
 });
@@ -46,12 +57,9 @@ describe("apiService", () => {
     });
 
     it("train returns updated losses", async () => {
-        const landmarks: [number, number, number][] = Array.from(
-            { length: 478 },
-            () => [0, 0, 0],
-        );
-        const batch: BatchItem[] = [{ landmarks, target: [3, 4] }];
-        const losses = await train(batch, 1, "train");
+        const landmarks = new Float32Array(478 * 3);
+        const targets = new Float32Array([3, 4]);
+        const losses = await train(landmarks, targets, 1, "train");
         expect(losses.loss).toBeGreaterThanOrEqual(0);
     });
 

--- a/src/apiService.ts
+++ b/src/apiService.ts
@@ -4,10 +4,10 @@ import type {
     iGazeDetectorTrainResult,
 } from "./training/Trainer";
 import { webOnnx } from "./runtime/WebOnnxAdapter";
+import { trainableOnnx } from "./runtime/TrainableOnnx";
+import type { PixelCoord } from "./util/Coords";
 
 let data_index = 0;
-let modelBias: [number, number] = [0, 0];
-
 let savedMlp: ArrayBuffer | null = null;
 
 try {
@@ -15,10 +15,6 @@ try {
         const raw = localStorage.getItem("gaze_mlp_trained");
         if (raw) {
             const parsed = JSON.parse(raw);
-            if (Array.isArray(parsed.bias) && parsed.bias.length === 2) {
-                modelBias[0] = parsed.bias[0];
-                modelBias[1] = parsed.bias[1];
-            }
             if (parsed.mlp) {
                 const arr = Uint8Array.from(parsed.mlp as number[]);
                 savedMlp = arr.buffer;
@@ -42,7 +38,6 @@ export async function save_gaze_model(): Promise<boolean> {
         const mlp = await webOnnx.exportMlpModel?.();
         if (!mlp) throw new Error("No MLP model available");
         const payload = {
-            bias: modelBias,
             mlp: Array.from(new Uint8Array(mlp)),
         };
         const json = JSON.stringify(payload);
@@ -66,41 +61,48 @@ export async function save_gaze_model(): Promise<boolean> {
 }
 
 export async function train(
-    batch: BatchItem[],
+    landmarks: Float32Array,
+    targets: Float32Array,
     epochs: number,
     action: "train" | "calibrate",
 ): Promise<iGazeDetectorTrainResult> {
     if (!webOnnx.ready) {
-        console.warn("ONNX model not ready; cannot train locally.", { batch, epochs, action });
+        console.warn("ONNX model not ready; cannot train locally.", { epochs, action });
         return { h_loss: 0, v_loss: 0, loss: 0 };
     }
 
+    const sampleCount = targets.length / 2;
+    const features = await trainableOnnx.transformPca(landmarks, sampleCount);
     const lr = action === "calibrate" ? 0.05 : 0.01;
-    let h_sum = 0;
-    let v_sum = 0;
-    let n = 0;
+    await trainableOnnx.trainMlpBatch(features, targets, sampleCount, epochs, lr);
 
-    for (let e = 0; e < epochs; e++) {
-        const preds = await webOnnx.predict(batch.map((b) => b.landmarks));
-        for (let i = 0; i < batch.length; i++) {
-            const item = batch[i];
-            if (!item.target) continue;
-            const [gx0, gy0] = preds[i];
-            const gx = gx0 + modelBias[0];
-            const gy = gy0 + modelBias[1];
-            const [tx, ty] = item.target;
-            const dx = tx - gx;
-            const dy = ty - gy;
-            modelBias[0] += lr * dx;
-            modelBias[1] += lr * dy;
-            h_sum += Math.abs(dx);
-            v_sum += Math.abs(dy);
-            n++;
-        }
+    const mlpBytes = await trainableOnnx.exportMlpModel();
+    if (mlpBytes) {
+        savedMlp = mlpBytes;
+        await webOnnx.init(mlpBytes);
     }
 
-    const h_loss = n ? h_sum / n : 0;
-    const v_loss = n ? v_sum / n : 0;
+    const batch: PixelCoord[][] = [];
+    for (let i = 0; i < sampleCount; i++) {
+        const sample: PixelCoord[] = [];
+        for (let j = 0; j < 478; j++) {
+            const base = i * 478 * 3 + j * 3;
+            sample.push([landmarks[base], landmarks[base + 1], landmarks[base + 2]]);
+        }
+        batch.push(sample);
+    }
+    const preds = await webOnnx.predict(batch);
+    let h_sum = 0;
+    let v_sum = 0;
+    for (let i = 0; i < sampleCount; i++) {
+        const [gx, gy] = preds[i];
+        const tx = targets[i * 2];
+        const ty = targets[i * 2 + 1];
+        h_sum += Math.abs(gx - tx);
+        v_sum += Math.abs(gy - ty);
+    }
+    const h_loss = sampleCount ? h_sum / sampleCount : 0;
+    const v_loss = sampleCount ? v_sum / sampleCount : 0;
     const loss = (h_loss + v_loss) / 2;
     return { h_loss, v_loss, loss };
 }
@@ -113,9 +115,7 @@ export async function post_data(
         return undefined;
     }
 
-    const [gx0, gy0] = (await webOnnx.predict([item.landmarks]))[0];
-    const gx = gx0 + modelBias[0];
-    const gy = gy0 + modelBias[1];
+    const [gx, gy] = (await webOnnx.predict([item.landmarks]))[0];
     let h_loss = 0;
     let v_loss = 0;
     let loss = 0;

--- a/src/runtime/TrainableOnnx.test.ts
+++ b/src/runtime/TrainableOnnx.test.ts
@@ -62,7 +62,7 @@ test('trainMlpBatch runs over epochs and returns average losses', async () => {
   const features = new Float32Array(4 * 32);
   const targets = new Float32Array(4 * 2);
 
-  const losses = await t.trainMlpBatch(features, targets, 2, 2);
+  const losses = await t.trainMlpBatch(features, targets, 2, 2, 0.01);
   expect(trainStep).toHaveBeenCalledTimes(4);
   expect(optimizerStep).toHaveBeenCalledTimes(4);
   expect(lazyResetGrad).toHaveBeenCalledTimes(4);

--- a/src/training/Trainer.ts
+++ b/src/training/Trainer.ts
@@ -105,7 +105,22 @@ export class Trainer extends EventEmitter implements IGazeTrainer {
                 let n = 0;
                 for (let i = 0; i < totalBatches; i++) {
                     const batch = data.slice(i * this.BATCH_SIZE, (i + 1) * this.BATCH_SIZE);
-                    const losses = await train(batch, 1, "train");
+                    const landmarks = new Float32Array(batch.length * 478 * 3);
+                    const targets = new Float32Array(batch.length * 2);
+                    for (let b = 0; b < batch.length; b++) {
+                        const item = batch[b];
+                        for (let j = 0; j < 478; j++) {
+                            const lm = item.landmarks[j];
+                            const base = b * 478 * 3 + j * 3;
+                            landmarks[base] = lm[0] ?? 0;
+                            landmarks[base + 1] = lm[1] ?? 0;
+                            landmarks[base + 2] = lm[2] ?? 0;
+                        }
+                        const t = item.target!;
+                        targets[b * 2] = t[0];
+                        targets[b * 2 + 1] = t[1];
+                    }
+                    const losses = await train(landmarks, targets, 1, "train");
                     h_sum += losses.h_loss * batch.length;
                     v_sum += losses.v_loss * batch.length;
                     n += batch.length;


### PR DESCRIPTION
## Summary
- train MLP using ONNX with PCA features and reload model weights after each training step
- expose MLP export and learning-rate control in TrainableOnnx adapter
- batch trainer supplies Float32 landmark/target arrays to API service

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c7bf689b14832a8baccc4ab4881bf7