### PR TITLE
docs: add TypeScript overview and inline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ This repository provides the web client for the Learn2See project, built with Vi
 
 Pre-trained ONNX models should be placed in `public/models` so they are available at `/models/` at runtime.
 Legacy Python utilities are preserved under `python/` for reference but are not served by the application.
+
+## Code Overview
+
+New to the project? Start with [doc/code-overview.md](doc/code-overview.md) for a tour of the TypeScript modules and how they fit together.

--- a/doc/code-overview.md
+++ b/doc/code-overview.md
@@ -1,0 +1,36 @@
+# TypeScript Code Overview
+
+This document summarizes the main modules in the Learn2See web client to help new contributors navigate the codebase.
+
+## Entry Point
+
+- **src/main.ts** – Bootstraps the application, initializes the ONNX runtime, wires up the UI, and starts monitoring backend availability.
+
+## Core Components
+
+- **src/GazeDetector.ts** – Coordinates webcam capture, landmark detection, gaze prediction, and target presentation. Emits events with prediction results and training feedback.
+- **src/GazeElement.ts** – Custom HTML element whose position represents either the predicted gaze point or a training target.
+- **src/UI.ts** – Holds references to DOM elements and reusable UI helpers.
+
+## Controllers
+
+- **src/controllers/GazeSession.ts** – Manages the lifecycle of gaze detection and optional model training sessions.
+- **src/controllers/TrainingPage.ts** – UI controller for the training view.
+
+## Services
+
+- **src/services/DataAcquisitionService.ts** – Drives the moving target used to collect labelled gaze samples.
+- **src/services/InputHandler.ts** – Handles keyboard shortcuts for saving models, toggling data acquisition, and starting calibration.
+- **src/services/NotificationService.ts** – Lightweight notification helper.
+
+## Runtime and Training Utilities
+
+- **src/runtime/WebOnnxAdapter.ts** – Wraps `onnxruntime-web` and exposes an async API for running PCA and MLP models in the browser.
+- **src/runtime/TrainableOnnx.ts** – Adds save/export support to ONNX sessions during training.
+- **src/training/Trainer.ts** – Orchestrates incremental training of the gaze model in the browser.
+
+## Helpers
+
+- **src/util/** – Miscellaneous utility functions such as coordinate conversions, buffer helpers, and navigation helpers.
+
+This overview is intentionally high level. Refer to source files for detailed implementation notes.

--- a/src/GazeDetector.ts
+++ b/src/GazeDetector.ts
@@ -1,3 +1,7 @@
+/*
+ * Coordinates webcam capture, landmark detection and gaze prediction.
+ * Manages training targets and emits events with prediction results.
+ */
 import EventEmitter from "eventemitter3";
 
 import {LandMarkDetector} from "./LandMarkDetector";

--- a/src/controllers/GazeSession.ts
+++ b/src/controllers/GazeSession.ts
@@ -1,3 +1,7 @@
+/*
+ * High-level controller for a gaze detection session.
+ * Manages detector lifecycle, training, and model persistence.
+ */
 import EventEmitter from "eventemitter3";
 
 import { GazeDetector } from "../GazeDetector";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,7 @@
+/*
+ * Application entry point. Sets up UI components, initializes the ONNX runtime,
+ * and starts gaze detection when requested by the user.
+ */
 import './styles/main.css';
 import { GazeElement } from "./GazeElement";
 import { GazeSession } from "./controllers/GazeSession";

--- a/src/runtime/WebOnnxAdapter.ts
+++ b/src/runtime/WebOnnxAdapter.ts
@@ -2,6 +2,10 @@
 // If you load ORT via <script src=".../ort.min.js">, use: const ort = (window as any).ort;
 import * as ort from 'onnxruntime-web';
 import { PixelCoord } from '../util/Coords';
+/**
+ * Thin wrapper around onnxruntime-web that loads PCA and MLP models and
+ * provides batched prediction and model export utilities for gaze inference.
+ */
 
 export class WebOnnxAdapter {
   private pcaSession?: ort.InferenceSession;

--- a/src/services/DataAcquisitionService.ts
+++ b/src/services/DataAcquisitionService.ts
@@ -1,3 +1,7 @@
+/*
+ * Controls the on-screen target used for collecting labelled gaze samples
+ * during calibration.
+ */
 import { GazeDetector } from "../GazeDetector";
 
 export class DataAcquisitionService {

--- a/src/services/InputHandler.ts
+++ b/src/services/InputHandler.ts
@@ -1,3 +1,7 @@
+/*
+ * Handles global keyboard shortcuts to control data capture, training,
+ * and model saving during a gaze session.
+ */
 import { GazeSession } from "../controllers/GazeSession";
 import { DataAcquisitionService } from "./DataAcquisitionService";
 import { notifications } from "./NotificationService";


### PR DESCRIPTION
## Summary
- document project structure in `doc/code-overview.md`
- link overview from README
- clarify major TypeScript modules with top-of-file comments

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68c81cc8f344832a9ef210f9ae2fb399