### PR TITLE
Initialize PCA before training and guard training dataset size

### DIFF
--- a/src/controllers/GazeSession.ts
+++ b/src/controllers/GazeSession.ts
@@ -53,11 +53,12 @@ export class GazeSession extends EventEmitter {
     }
   }
 
-  public async StartTraining() {
+  public StartTraining(): boolean {
     if (this.trainer && !this.trainer.isTraining) {
       this.epoch = 0;
-      this.trainer.startTraining();
+      return this.trainer.startTraining();
     }
+    return false;
   }
 
   public async StopTraining() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { TabNavigator } from "./util/nav";
 import { apiAvailable, getSavedGazeModel } from "./apiService";
 import { Fullscreen } from "./util/util";
 import { webOnnx } from "./runtime/WebOnnxAdapter";
+import { trainableOnnx } from "./runtime/TrainableOnnx";
 import { PixelCoord } from "./util/Coords";
 import { ui } from "./UI";
 
@@ -59,7 +60,10 @@ function monitorApiStatus() {
 }
 
 export async function bootstrap() {
-    await webOnnx.init(getSavedGazeModel() ?? undefined);
+    await Promise.all([
+        webOnnx.init(getSavedGazeModel() ?? undefined),
+        trainableOnnx.init(),
+    ]);
     await webOnnx.predict([Array.from({ length: 478 }, () => [0, 0, 0] as PixelCoord)]);
     initUI();
     monitorApiStatus();

--- a/src/services/InputHandler.ts
+++ b/src/services/InputHandler.ts
@@ -28,13 +28,17 @@ export class InputHandler {
           : "Data acquisition stopped."
       );
     } else if (evt.key === "c") {
-      if (this.session.isTrainingActive) await this.session.StopTraining();
-      else await this.session.StartTraining();
-      notifications.notify(
-        this.session.isTrainingActive
-          ? "Calibration started."
-          : "Calibration stopped."
-      );
+      if (this.session.isTrainingActive) {
+        await this.session.StopTraining();
+        notifications.notify("Calibration stopped.");
+      } else {
+        const started = this.session.StartTraining();
+        notifications.notify(
+          started
+            ? "Calibration started."
+            : "Not enough data to start training."
+        );
+      }
     }
   };
 

--- a/src/training/Trainer.ts
+++ b/src/training/Trainer.ts
@@ -21,7 +21,7 @@ export type BatchItem = {
 };
 
 export interface IGazeTrainer extends EventEmitter {
-    startTraining(): void;
+    startTraining(): boolean;
     stopTraining(): Promise<void>;
     addSample(sample: BatchItem): void;
     readonly isTraining: boolean;
@@ -65,11 +65,13 @@ export class Trainer extends EventEmitter implements IGazeTrainer {
         return this.epochCounter;
     }
 
-    startTraining() {
-        if (this.trainingActive) return;
+    startTraining(): boolean {
+        if (this.trainingActive) return false;
+        if (this.dataset.length < this.BATCH_SIZE) return false;
         this.trainingActive = true;
         this.epochCounter = 0;
         this.trainingLoop = this.runTrainingLoop();
+        return true;
     }
 
     async stopTraining() {


### PR DESCRIPTION
## Summary
- Initialize TrainableOnnx PCA/MLP adapters on bootstrap
- Require at least one full batch of samples before starting training
- Notify user when insufficient data prevents training

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c8224b02e4832aa2fd0d63f426036a