### PR TITLE
Configure ORT loading for cross-origin isolation

### DIFF
--- a/src/runtime/WebOnnxAdapter.ts
+++ b/src/runtime/WebOnnxAdapter.ts
@@ -1,45 +1,104 @@
 // src/runtime/WebOnnxAdapter.ts
 // If you load ORT via <script src=".../ort.min.js">, use: const ort = (window as any).ort;
-import * as ort from 'onnxruntime-web';
+import type * as ortTypes from 'onnxruntime-web';
 import { PixelCoord } from '../util/Coords';
+
+type OrtModule = typeof import('onnxruntime-web');
+
+type OrtConfig = {
+  logLevel: 'warning';
+  wasm: {
+    simd: boolean;
+    proxy: boolean;
+    multiThread: boolean;
+    numThreads: number;
+    wasmPaths: string;
+  };
+};
+
+type GlobalOrt = {
+  env?: {
+    wasm?: Record<string, unknown>;
+    logLevel?: OrtConfig['logLevel'];
+  };
+};
+
+const ensureGlobalOrt = (): GlobalOrt & { env: { wasm: Record<string, unknown> } } => {
+  const globalScope = globalThis as typeof globalThis & { ort?: GlobalOrt };
+  if (!globalScope.ort) {
+    globalScope.ort = { env: { wasm: {} } };
+  } else {
+    const ortEnv = globalScope.ort.env ?? (globalScope.ort.env = { wasm: {} });
+    if (!ortEnv.wasm) {
+      ortEnv.wasm = {};
+    }
+  }
+  return globalScope.ort as GlobalOrt & { env: { wasm: Record<string, unknown> } };
+};
+
+const buildOrtConfig = (): OrtConfig => {
+  const supportsMultiThreading =
+    typeof window !== 'undefined' &&
+    window.crossOriginIsolated === true &&
+    typeof SharedArrayBuffer !== 'undefined';
+
+  const hardwareConcurrency =
+    typeof navigator !== 'undefined' && typeof navigator.hardwareConcurrency === 'number'
+      ? navigator.hardwareConcurrency
+      : 1;
+
+  return {
+    logLevel: 'warning',
+    wasm: {
+      simd: true,
+      proxy: false,
+      multiThread: supportsMultiThreading,
+      numThreads: supportsMultiThreading ? Math.min(4, Math.max(1, hardwareConcurrency)) : 1,
+      wasmPaths: '/ort/',
+    },
+  };
+};
+
+const applyConfigToGlobalOrt = (config: OrtConfig) => {
+  const ort = ensureGlobalOrt();
+  ort.env.logLevel = config.logLevel;
+  Object.assign(ort.env.wasm, config.wasm);
+};
+
+let ortModulePromise: Promise<OrtModule> | null = null;
+
+const loadOrt = async (config: OrtConfig): Promise<OrtModule> => {
+  applyConfigToGlobalOrt(config);
+  if (!ortModulePromise) {
+    ortModulePromise = import('onnxruntime-web');
+  }
+  const ort = await ortModulePromise;
+  ort.env.logLevel = config.logLevel;
+  Object.assign(ort.env.wasm, config.wasm);
+  return ort;
+};
 /**
  * Thin wrapper around onnxruntime-web that loads PCA and MLP models and
  * provides batched prediction and model export utilities for gaze inference.
  */
 
 export class WebOnnxAdapter {
-  private pcaSession?: ort.InferenceSession;
-  private mlpSession?: ort.InferenceSession;
+  private ort?: OrtModule;
+  private pcaSession?: ortTypes.InferenceSession;
+  private mlpSession?: ortTypes.InferenceSession;
   ready = false;
   private _queue: Promise<unknown> = Promise.resolve();
 
   async init(mlpBytes?: ArrayBuffer) {
-    // Configure ORT's environment. Prefer multi-threading only when the page
-    // is cross-origin isolated (the only scenario where SharedArrayBuffer is
-    // available) and always avoid proxy workers. When proxy workers were
-    // enabled, the main bundle was executed in a WebWorker that lacks a DOM,
-    // which surfaced as "document is not defined" errors in the console.
-    const env = (window as any).ort?.env ?? ort.env;
-    env.logLevel = 'warning';
-    env.wasm.simd = true;
+    // Configure ORT before importing so the runtime picks the correct WASM
+    // variant. Multi-threading is only enabled when cross-origin isolation is
+    // available; otherwise we explicitly fall back to the single-threaded
+    // ort-wasm-simd build and avoid proxy workers that spawn WebWorkers.
+    const config = buildOrtConfig();
+    const ort = await loadOrt(config);
+    this.ort = ort;
 
-    const supportsMultiThreading =
-      typeof window !== 'undefined' &&
-      window.crossOriginIsolated === true &&
-      typeof SharedArrayBuffer !== 'undefined';
-    const hardwareConcurrency =
-      typeof navigator !== 'undefined' && typeof navigator.hardwareConcurrency === 'number'
-        ? navigator.hardwareConcurrency
-        : 1;
-
-    env.wasm.numThreads = supportsMultiThreading ? Math.min(4, Math.max(1, hardwareConcurrency)) : 1;
-    env.wasm.proxy = false;
-    // ORT expects its wasm assets relative to this path. Vite copies the
-    // binaries into /ort at the public root, so reference that location
-    // directly.
-    env.wasm.wasmPaths = '/ort/';
-
-    const createSessionOptions = (): ort.InferenceSession.SessionOptions => ({
+    const createSessionOptions = (): ortTypes.InferenceSession.SessionOptions => ({
       executionProviders: ['webgpu', 'wasm'],
       graphOptimizationLevel: 'all',
       extra: { 'session.use_ort_model_bytes_directly': '1' },
@@ -89,13 +148,16 @@ export class WebOnnxAdapter {
       }
     }
 
+    const ort = this.ort;
+    if (!ort) throw new Error('ORT module not loaded');
+
     const pcaInput = new ort.Tensor('float32', flat, [B, 478, 3]);
     const pcaOutMap = await this.pcaSession.run({ [this.pcaSession.inputNames[0]]: pcaInput });
-    const pcaOut = pcaOutMap[this.pcaSession.outputNames[0]] as ort.Tensor;
+    const pcaOut = pcaOutMap[this.pcaSession.outputNames[0]] as ortTypes.Tensor;
 
     const mlpInput = new ort.Tensor('float32', pcaOut.data as Float32Array, [B, 32]);
     const mlpOutMap = await this.mlpSession.run({ [this.mlpSession.inputNames[0]]: mlpInput });
-    const mlpOut = mlpOutMap[this.mlpSession.outputNames[0]] as ort.Tensor;
+    const mlpOut = mlpOutMap[this.mlpSession.outputNames[0]] as ortTypes.Tensor;
     const v = mlpOut.data as Float32Array;
     const out: [number, number][] = [];
     for (let b = 0; b < B; b++) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,18 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 import path from 'path';
 
 export default defineConfig({
+  server: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    },
+  },
+  preview: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    },
+  },
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- add COOP/COEP headers to Vite dev and preview servers to enable cross-origin isolation
- configure the onnxruntime-web environment before importing it, picking the threaded build only when cross-origin isolation is available and otherwise forcing the single-threaded SIMD build

## Testing
- npm run dev
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68c839624e44832a9599debab83077b4